### PR TITLE
Add 'is new' flag to session

### DIFF
--- a/src/javascript/core.js
+++ b/src/javascript/core.js
@@ -75,6 +75,8 @@ function track(config, callback) {
 
 	var request = utils.merge(defaultConfig(), utils.merge(config, { callback: callback }));
 
+	var session = Session.session();
+
 	/* Values here are kinda the mandatory ones, so we want to make sure they're possible. */
 	request = utils.merge({
 		context: {
@@ -85,7 +87,8 @@ function track(config, callback) {
 		user: settings.get('config') ? settings.get('config').user : {},
 
 		device: {
-			spoor_session: Session.session(),
+			spoor_session: session.id,
+			spoor_session_is_new: session.isNew,
 			spoor_id: User.userID(),
 			user_agent: window.navigator.userAgent
 		}

--- a/src/javascript/core/session.js
+++ b/src/javascript/core/session.js
@@ -32,7 +32,8 @@ function setSession(session) {
  * @return {String} the current session
  */
 function getSession() {
-	var s = store.read(),
+	var isNew = false,
+		s = store.read(),
 		session;
 
 	if (s) {
@@ -48,12 +49,16 @@ function getSession() {
 	// No active session, gen a new one.
 	if (!session) {
 		session = utils.guid();
+		isNew = true;
 	}
 
 	// Refreshes the cookie...
 	setSession(session);
 
-	return session;
+	return {
+		id: session,
+		isNew: isNew
+	};
 }
 
 /**

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -78,8 +78,9 @@ describe('Core', function () {
 			assert.equal(sent_data.user.user_id, "userID");
 
 			// Device
-			assert.deepEqual(Object.keys(sent_data.device), ["spoor_session","spoor_id","user_agent"]);
-			assert.equal(sent_data.device.spoor_session, require("../src/javascript/core/session").session());
+			assert.deepEqual(Object.keys(sent_data.device), ["spoor_session","spoor_session_is_new","spoor_id","user_agent"]);
+			assert.equal(sent_data.device.spoor_session, require("../src/javascript/core/session").session().id);
+			assert.equal(sent_data.device.spoor_session_is_new, require("../src/javascript/core/session").session().isNew);
 			assert.equal(sent_data.device.user_agent, ua);
 		});
 

--- a/test/core/session.test.js
+++ b/test/core/session.test.js
@@ -1,4 +1,4 @@
-/*global require, describe, it, beforeEach, afterEach */
+/*global require, describe, it, before, afterEach */
 "use strict";
 
 var assert = require('assert'),
@@ -7,11 +7,11 @@ var assert = require('assert'),
 
 describe('Core.Session', function () {
 
-	var session;
-
-	beforeEach(function () {
+	before(function () {
+		// clean up previous any tests
 		(new Store('session')).destroy();
 	});
+
 	afterEach(function () {
 		(new Store('session')).destroy();
 	});
@@ -19,20 +19,23 @@ describe('Core.Session', function () {
 	describe('no preset value', function () {
 		it('should init', function () {
 			assert.doesNotThrow(function () {
-				session = Session.init();
+				Session.init();
 			});
 		});
 
 		it('should use generate an ID if one does not exist', function () {
-			assert.equal(Session.session(), session);
+			var session = Session.init();
+			assert.notEqual(session.id, null);
+			assert.equal(session.isNew, true);
 		});
 	});
 
 	describe('retrieving values.', function () {
 		it('should use the existing value until it expires.', function () {
-			Session.session(); // Bug in karma, I think it's concurrent running tests - this seems to fix it.
-			Session.init();
-			assert.equal(Session.session(), session);
+			var session = Session.init();
+			var newSession = Session.session();
+			assert.equal(newSession.id, session.id);
+			assert.equal(newSession.isNew, false);
 		});
 	});
 

--- a/test/core/session.test.js
+++ b/test/core/session.test.js
@@ -8,7 +8,7 @@ var assert = require('assert'),
 describe('Core.Session', function () {
 
 	before(function () {
-		// clean up previous any tests
+		// clean up previous tests' pollution
 		(new Store('session')).destroy();
 	});
 


### PR DESCRIPTION
It would be useful to know whether the session has just started for data analysis, e.g. what area of the site do users begin their session, where do they come from, etc

This adds a `spoor_session_is_new` field: `true` when a session has just been created, `false` until it expires