### PR TITLE
Queue bug

### DIFF
--- a/src/javascript/core/queue.js
+++ b/src/javascript/core/queue.js
@@ -47,7 +47,7 @@ const Queue = function (name) {
  */
 Queue.prototype.all = function () {
 	if (this.queue.length === 0) {
-		return null;
+		return [];
 	}
 
 	const items = [];

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -99,7 +99,7 @@ function sendRequest(request, callback) {
 	const transport = createTransport();
 	const user_callback = request.callback;
 
-    const core_system = settings.get('config') && settings.get('config').system || {};
+	const core_system = settings.get('config') && settings.get('config').system || {};
 	const system = utils.merge(core_system, {
 		api_key: settings.get('api_key'), // String - API key - Make sure the request is from a valid client (idea nicked from Keen.io) useful if a page gets copied onto a Russian website and creates noise
 		version: settings.get('version'), // Version of the tracking client e.g. '1.2'
@@ -215,6 +215,8 @@ function init() {
 
 	// On startup, try sending any requests queued from a previous session.
 	run();
+
+	return queue;
 }
 
 module.exports = {

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -43,13 +43,4 @@ describe('Core.Send', function () {
 		});
 	});
 
-	/*let test_request = nock('http://trace.ft.com')
-	 .post('/')
-	 .reply(200, 'ok');
-
-	 it('should send the request', function () {
-	 Send.run(function () {
-	 assert.ok(test_request.isDone());
-	 });
-	 });*/
 });


### PR DESCRIPTION
- If queue length is very large, could be due to a bug in a previous version
- This was fixed in 1.0.14 - https://github.com/Financial-Times/o-tracking/compare/1.0.13...1.0.14
- But, still seeing big queues coming through in the data, as users come back to the site.
- This tries to catch those big queues and forcibly empty them.