### PR TITLE
added send beacon transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ node_js:
 before_install:
   - npm install -g Financial-Times/origami-build-tools#node4
   - obt install
-	- export CHROME_BIN=chromium-browser
-	- export DISPLAY=:99.0
-	- sh -e /etc/init.d/xvfb start
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 script:
   - obt test
   - obt verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: node_js
 sudo: false
 node_js:
   - "4"
+addons:
+  firefox: "latest"
 before_install:
-  - npm install -g Financial-Times/origami-build-tools#node4
+  - npm install -g origami-build-tools
   - obt install
-  - export CHROME_BIN=chromium-browser
+before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
 before_install:
   - npm install -g Financial-Times/origami-build-tools#node4
   - obt install
+	- export CHROME_BIN=chromium-browser
+	- export DISPLAY=:99.0
+	- sh -e /etc/init.d/xvfb start
 script:
   - obt test
   - obt verify

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,6 +15,7 @@ module.exports = function(karma) {
 		// list of files / patterns to load in the browser
 		files: [
 			'http://polyfill.webservices.ft.com/v1/polyfill.js?ua=safari/4',
+			'test/setup.js',
 			'test/**/*.test.js'
 		],
 
@@ -27,7 +28,7 @@ module.exports = function(karma) {
 		// preprocess matching files before serving them to the browser
 		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 		preprocessors: {
-			'test/**/*.test.js': ['browserify']
+			'test/**/*.js': ['browserify']
 		},
 
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,9 +16,7 @@ module.exports = function(karma) {
 		files: [
 			'http://polyfill.webservices.ft.com/v1/polyfill.js',
 			'test/setup.js',
-			// 'test/core.test.js',
-			'test/main.test.js',
-			// 'test/utils.test.js'
+			'test/**/*.test.js'
 		],
 
 
@@ -37,7 +35,7 @@ module.exports = function(karma) {
 		// test results reporter to use
 		// possible values: 'dots', 'progress'
 		// available reporters: https://npmjs.org/browse/keyword/karma-reporter
-		reporters: ['progress'],
+		reporters: ['dots'],
 
 
 		// web server port

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
 /*global module*/
 
-module.exports = function(config) {
-	config.set({
+module.exports = function(karma) {
+	var config = {
 
 		// base path that will be used to resolve all patterns (eg. files, exclude)
 		basePath: '',
@@ -47,7 +47,7 @@ module.exports = function(config) {
 
 		// level of logging
 		// possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-		logLevel: config.LOG_INFO,
+		logLevel: karma.LOG_INFO,
 
 
 		// enable / disable watching file and executing tests whenever any file changes
@@ -56,7 +56,7 @@ module.exports = function(config) {
 
 		// start these browsers
 		// available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-		browsers: ['PhantomJS'],
+		browsers: ['Chrome'],
 
 
 		// Continuous Integration mode
@@ -66,7 +66,19 @@ module.exports = function(config) {
 		browserify: {
 			debug: true,
 			transform: [ 'babelify', 'debowerify' ]
-		}
+		},
 
-	});
+		customLaunchers: {
+			Chrome_travis_ci: {
+				base: 'Chrome',
+				flags: ['--no-sandbox']
+			}
+		}
+	};
+
+	if(process.env.TRAVIS){
+		config.browsers = ['Chrome_travis_ci'];
+	}
+
+	karma.set(config);
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,9 +14,11 @@ module.exports = function(karma) {
 
 		// list of files / patterns to load in the browser
 		files: [
-			'http://polyfill.webservices.ft.com/v1/polyfill.js?ua=safari/4',
+			'http://polyfill.webservices.ft.com/v1/polyfill.js',
 			'test/setup.js',
-			'test/**/*.test.js'
+			// 'test/core.test.js',
+			'test/main.test.js',
+			// 'test/utils.test.js'
 		],
 
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
-/*global module*/
+/*global module, process*/
 
 module.exports = function(karma) {
-	var config = {
+	const config = {
 
 		// base path that will be used to resolve all patterns (eg. files, exclude)
 		basePath: '',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,4 @@
-/*global module, process*/
+/*global module*/
 
 module.exports = function(karma) {
 	const config = {
@@ -56,7 +56,7 @@ module.exports = function(karma) {
 
 		// start these browsers
 		// available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-		browsers: ['Chrome'],
+		browsers: ['Firefox'],
 
 
 		// Continuous Integration mode
@@ -66,19 +66,10 @@ module.exports = function(karma) {
 		browserify: {
 			debug: true,
 			transform: [ 'babelify', 'debowerify' ]
-		},
-
-		customLaunchers: {
-			Chrome_travis_ci: {
-				base: 'Chrome',
-				flags: ['--no-sandbox']
-			}
 		}
+
 	};
 
-	if(process.env.TRAVIS){
-		config.browsers = ['Chrome_travis_ci'];
-	}
 
 	karma.set(config);
 };

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ const send = require('./src/javascript/core/send');
  * The version of the tracking module.
  * @type {string}
  */
-const version = '1.0.14';
+const version = '1.0.15';
 /**
  * The source of this event.
  * @type {string}

--- a/origami.json
+++ b/origami.json
@@ -6,8 +6,9 @@
     "supportStatus": "active",
     "browserFeatures": {
         "required": [
-            "CustomEvent"    
-        ]  
+            "CustomEvent",
+            "Promise"
+        ]
     },
     "demos": [
         {

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
     "test": "./node_modules/karma/bin/karma start karma.conf.js"
   },
   "devDependencies": {
+    "babelify": "^6.1.3",
     "debowerify": "Financial-Times/debowerify",
-    "karma-browserify": "^4.0.0",
-    "mocha": "^2.2.1",
-    "karma-phantomjs-launcher": "^0.1.4",
     "karma": "^0.12.31",
+    "karma-browserify": "^4.0.0",
+    "karma-chrome-launcher": "^0.2.2",
     "karma-mocha": "^0.1.10",
-    "nock": "^1.2.1",
-    "sinon": "^1.14.1",
+    "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon": "^1.0.4",
-    "babelify": "^6.1.3"
+    "mocha": "^2.2.1",
+    "nock": "^1.2.1",
+    "sinon": "^1.14.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "karma": "^0.12.31",
     "karma-browserify": "^4.0.0",
     "karma-chrome-launcher": "^0.2.2",
+    "karma-firefox-launcher": "^0.1.7",
     "karma-mocha": "^0.1.10",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon": "^1.0.4",

--- a/src/javascript/core.js
+++ b/src/javascript/core.js
@@ -105,7 +105,6 @@ function track(config, callback) {
 	}, request);
 
 	utils.log('Core.Track', request);
-
 	// Send it.
 	Send.addAndRun(request);
 

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -28,7 +28,7 @@ let queue;
 function sendRequest(request, callback) {
 	const offlineLag = (new Date()).getTime() - request.queueTime;
 	let path;
-	const transport = navigator.sendBeacon ? sendBeacon() : window.XMLHttpRequest && 'withCredentials' in new window.XMLHttpRequest() ? xhr() : image();
+	const transport = (navigator.sendBeacon && Promise) ? sendBeacon() : window.XMLHttpRequest && 'withCredentials' in new window.XMLHttpRequest() ? xhr() : image();
 	const user_callback = request.callback;
 
 	const core_system = settings.get('config') && settings.get('config').system || {};

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -91,9 +91,11 @@ function sendRequest(request, callback) {
  */
 function add(request) {
 	request.queueTime = (new Date()).getTime();
-
-	queue.add(request).save();
-
+	if (navigator.sendBeacon && Promise) {
+		sendRequest(request);
+	} else {
+		queue.add(request).save();
+	}
 	utils.log('AddedToQueue', queue);
 }
 

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -30,7 +30,7 @@ function sendRequest(request, callback) {
 	const queueTime = request.queueTime;
 	const offlineLag = new Date().getTime() - queueTime;
 	let path;
-	const transport = (navigator.sendBeacon && Promise) ? transports.get('sendBeacon')() :
+	const transport = (navigator.sendBeacon && Promise && settings.get('useSendBeacon')) ? transports.get('sendBeacon')() :
 										window.XMLHttpRequest && 'withCredentials' in new window.XMLHttpRequest() ? transports.get('xhr')() :
 										transports.get('image')();
 	const user_callback = request.callback;

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -45,7 +45,7 @@ function sendRequest(request, callback) {
 		request.time = request.time || {};
 		request.time.offset = offlineLag;
 	}
-
+	console.log(request.callback)
 	delete request.callback;
 	delete request.async;
 	delete request.type;

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -28,7 +28,7 @@ let queue;
 function sendRequest(request, callback) {
 	const offlineLag = (new Date()).getTime() - request.queueTime;
 	let path;
-	const transport = navigator.sendBeacon ? sendBeacon() : window.XMLHttpRequest && 'withCredentials' in window.XMLHttpRequest.prototype ? xhr() : image();
+	const transport = navigator.sendBeacon ? sendBeacon() : window.XMLHttpRequest && 'withCredentials' in new window.XMLHttpRequest() ? xhr() : image();
 	const user_callback = request.callback;
 
 	const core_system = settings.get('config') && settings.get('config').system || {};
@@ -58,9 +58,9 @@ function sendRequest(request, callback) {
 
 	utils.log('path', path);
 
-	transport.complete(function (error, t) {
+	transport.complete(function (error) {
 		if (utils.is(user_callback, 'function')) {
-			user_callback.call(request, t);
+			user_callback.call(request);
 			utils.log('calling user_callback');
 		}
 
@@ -108,7 +108,10 @@ function run(callback) {
 		callback = function () {};
 	}
 
-	const next = function () { run(); callback(); };
+	const next = function () {
+		run();
+		callback();
+	};
 	const nextRequest = queue.shift();
 
 	// Cancel if we've run out of requests.

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -6,9 +6,7 @@
 const settings = require('./settings');
 const utils = require('../utils');
 const Queue = require('./queue');
-const xhr = require('./transports/xhr');
-const sendBeacon = require('./transports/send-beacon');
-const image = require('./transports/image');
+const transports = require('./transports');
 /**
  * Default collection server.
  */
@@ -32,7 +30,9 @@ function sendRequest(request, callback) {
 	const queueTime = request.queueTime;
 	const offlineLag = new Date().getTime() - queueTime;
 	let path;
-	const transport = (navigator.sendBeacon && Promise) ? sendBeacon() : window.XMLHttpRequest && 'withCredentials' in new window.XMLHttpRequest() ? xhr() : image();
+	const transport = (navigator.sendBeacon && Promise) ? transports.get('sendBeacon')() :
+										window.XMLHttpRequest && 'withCredentials' in new window.XMLHttpRequest() ? transports.get('xhr')() :
+										transports.get('image')();
 	const user_callback = request.callback;
 
 	const core_system = settings.get('config') && settings.get('config').system || {};

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -59,7 +59,6 @@ const Store = function (name, config) {
 
 					if (window.localStorage.getItem(test_key) === 'TEST') {
 						window.localStorage.removeItem(test_key);
-
 						return {
 							_type: 'localStorage',
 							load: function (name) { return window.localStorage.getItem.call(window.localStorage, name); },

--- a/src/javascript/core/transports/image.js
+++ b/src/javascript/core/transports/image.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const utils = require('../../utils');
 
 module.exports = function () {

--- a/src/javascript/core/transports/image.js
+++ b/src/javascript/core/transports/image.js
@@ -1,0 +1,18 @@
+module.exports = function () {
+	const image = new Image(1,1);
+
+	return {
+		send: function (domain, path) {
+			image.src = domain + '?data=' + utils.encode(path);
+		},
+		complete: function (callback) {
+			if (image.addEventListener) {
+				image.addEventListener('error', callback);
+				image.addEventListener('load', () => callback());
+			} else { // it's IE!
+				image.attachEvent('onerror', callback);
+				image.attachEvent('onload', () => callback());
+			}
+		}
+	};
+}

--- a/src/javascript/core/transports/image.js
+++ b/src/javascript/core/transports/image.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const utils = require('../../utils');
+
 module.exports = function () {
 	const image = new Image(1,1);
 

--- a/src/javascript/core/transports/index.js
+++ b/src/javascript/core/transports/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+	xhr: require('./xhr'),
+	sendBeacon: require('./send-beacon'),
+	image: require('./image'),
+	get: function (name) {
+		return this.mock || this[name];
+	}
+}

--- a/src/javascript/core/transports/index.js
+++ b/src/javascript/core/transports/index.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = {
 	xhr: require('./xhr'),
 	sendBeacon: require('./send-beacon'),

--- a/src/javascript/core/transports/send-beacon.js
+++ b/src/javascript/core/transports/send-beacon.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = function () {
+    let resolver;
+    let rejecter;
+    const p = new Promise((resolve, reject) => {
+        resolver = resolve;
+        rejecter = reject;
+    })
+    return {
+        send: function (domain, path) {
+            if (navigator.sendBeacon(path, domain)) {
+                resolver();
+            } else {
+                rejecter(new Error('Failed to send beacon event: ' + domain.toString()));
+            }
+
+        },
+        complete: function (callback) {
+            p.then(callback, callback);
+        }
+    };
+};

--- a/src/javascript/core/transports/send-beacon.js
+++ b/src/javascript/core/transports/send-beacon.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = function () {
     let resolver;
     let rejecter;

--- a/src/javascript/core/transports/send-beacon.js
+++ b/src/javascript/core/transports/send-beacon.js
@@ -6,7 +6,7 @@ module.exports = function () {
     const p = new Promise((resolve, reject) => {
         resolver = resolve;
         rejecter = reject;
-    })
+    });
     return {
         send: function (domain, path) {
             if (navigator.sendBeacon(path, domain)) {

--- a/src/javascript/core/transports/xhr.js
+++ b/src/javascript/core/transports/xhr.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = function () {
 	const xhr = new window.XMLHttpRequest();
 

--- a/src/javascript/core/transports/xhr.js
+++ b/src/javascript/core/transports/xhr.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = function () {
+	const xhr = new window.XMLHttpRequest();
+
+	xhr.withCredentials = true;
+
+	return {
+		send: function (domain, path) {
+			xhr.open('POST', domain, true);
+			xhr.setRequestHeader('Content-type', 'application/json');
+			xhr.send(path);
+		},
+		complete: function (callback) {
+			xhr.onerror = callback;
+			xhr.onload = () => callback();
+		}
+	};
+}

--- a/src/javascript/events/link-click.js
+++ b/src/javascript/events/link-click.js
@@ -112,7 +112,7 @@ function createLinkID(link) {
 	const parents = parentTree(link);
 	let name = link.href || link.text || link.name || link.id;
 
-	name = name.replace(/^http:\/\/[\w\.]+/, '') // Remove http://[something].
+	name = name.replace(/^http:\/\/[\w\.\:]+/, '') // Remove http://[something].
 		.replace(/^\//, '') // Remove slash at beginning
 		.replace(/(\?|#).*$/, '') // Remove query string and page anchor (#)
 		.replace(/\/$/, '') // Remove trailing slash
@@ -201,7 +201,6 @@ function onClick(cb) {
 function runQueue() {
 	const next = function () { runQueue(); callback(); };
 	const nextLink = internalQueue.shift();
-
 	if (nextLink) {
 		Core.track(nextLink, next);
 	}

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -75,7 +75,7 @@ function merge(target, options) {
 		}
 
 		// Gets rid of missing values too
-		if (typeof copy !== 'undefined' && copy !== null && copy !== '') {
+		if (typeof copy !== 'undefined' && copy !== null) {
 			target[name] = (src === Object(src) && !is(src, 'function') ? merge(src, copy) : copy);
 		}
 	}

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -23,7 +23,6 @@ describe('Core', function () {
 	});
 
 	describe('track', function () {
-		let server;
 
 		before(function () {
 			settings.set('version', '1.0.0');

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -26,13 +26,18 @@ const request = {
 	}
 };
 
+const setup = require('../setup');
+
 // PhantomJS doesn't always create a "fresh" environment...
 
 describe('Core.Send', function () {
-
+	before(function () {
+		setup.unmockTransport();
+	})
 	after(function () {
 		(new Queue('requests')).replace([]);
 		require("../../src/javascript/core/settings").destroy('config');  // Empty settings.
+		setup.mockTransport();
 	});
 
 	it('should init first', function () {

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -43,4 +43,89 @@ describe('Core.Send', function () {
 		});
 	});
 
+	describe('fallback transports', function () {
+		it('fallback to xhr when sendBeacon not supported', function (done) {
+			Send.init();
+			const b = navigator.sendBeacon;
+			navigator.sendBeacon = null;
+			const xhr = window.XMLHttpRequest;
+			const dummyXHR = {
+				withCredentials: false,
+				open: sinon.stub(),
+				setRequestHeader: sinon.stub(),
+				send: sinon.stub()
+			};
+			window.XMLHttpRequest = function () {
+				return dummyXHR;
+			}
+			Send.addAndRun(request);
+			setTimeout(() => {
+				assert.equal(typeof dummyXHR.onerror, 'function');
+				assert.equal(typeof dummyXHR.onload, 'function');
+				assert.equal(dummyXHR.onerror.length, 1) // it will get passed the error
+				assert.equal(dummyXHR.onload.length, 0) // it will not get passed an error
+				assert.ok(dummyXHR.withCredentials);
+				assert.ok(dummyXHR.open.calledWith("POST", "http://test.spoor-api.ft.com", true));
+				assert.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'));
+				assert.ok(dummyXHR.send.calledOnce);
+				window.XMLHttpRequest = xhr;
+				navigator.sendBeacon = b;
+				done();
+			}, 100)
+		});
+
+		it('fallback to image when xhr withCredentials and sendBeacon not supported', function (done) {
+			Send.init();
+			const b = navigator.sendBeacon;
+			navigator.sendBeacon = null;
+			const xhr = window.XMLHttpRequest;
+			window.XMLHttpRequest = function () {
+				return {};
+			}
+			const dummyImage = {
+				addEventListener: sinon.stub()
+			};
+			const i = window.Image;
+			window.Image = sinon.stub().returns(dummyImage);
+			Send.addAndRun(request);
+			setTimeout(() => {
+				assert.ok(dummyImage.src, 'http://test.spoor-api.ft.com?data=%7B%22system%22%…1.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
+				assert.equal(dummyImage.addEventListener.args[0][0], 'error');
+				assert.equal(dummyImage.addEventListener.args[0][1].length, 1);// it will get passed the error
+				assert.equal(dummyImage.addEventListener.args[1][0], 'load');
+				assert.equal(dummyImage.addEventListener.args[1][1].length, 0);// it will get passed the error
+				window.XMLHttpRequest = xhr;
+				window.Image = i;
+				navigator.sendBeacon = b;
+				done();
+			}, 100)
+		});
+
+		it('fallback to image with attachEvent() when user is living in the past', function (done) {
+			Send.init();
+			const b = navigator.sendBeacon;
+			navigator.sendBeacon = null;
+			const xhr = window.XMLHttpRequest;
+			window.XMLHttpRequest = function () {
+				return {};
+			}
+			const dummyImage = {
+				attachEvent: sinon.stub()
+			};
+			const i = window.Image;
+			window.Image = sinon.stub().returns(dummyImage);
+			Send.addAndRun(request);
+			setTimeout(() => {
+				assert.ok(dummyImage.src, 'http://test.spoor-api.ft.com?data=%7B%22system%22%…1.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
+				assert.equal(dummyImage.attachEvent.args[0][0], 'onerror');
+				assert.equal(dummyImage.attachEvent.args[0][1].length, 1);// it will get passed the error
+				assert.equal(dummyImage.attachEvent.args[1][0], 'onload');
+				assert.equal(dummyImage.attachEvent.args[1][1].length, 0);// it will get passed the error
+				window.XMLHttpRequest = xhr;
+				window.Image = i;
+				navigator.sendBeacon = b;
+				done();
+			}, 100)
+		});
+	})
 });

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -1,4 +1,4 @@
-/*global require, describe, it */
+/*global require, describe, it, sinon */
 
 const assert = require('assert');
 const Send = require('../../src/javascript/core/send');

--- a/test/events/custom.test.js
+++ b/test/events/custom.test.js
@@ -22,7 +22,7 @@ describe('event', function () {
 		settings.destroy('config');  // Empty settings.
 	});
 
-	it('should track an event, adds custom component_id', function (done) {
+	it('should track an event, adds custom component_id', function () {
 
 		const callback = sinon.spy();
 		let sent_data;
@@ -37,25 +37,21 @@ describe('event', function () {
 			}
 		}), callback);
 
-		setTimeout(() => {
-			assert.ok(callback.called, 'Callback not called.');
+		assert.ok(callback.called, 'Callback not called.');
 
-			sent_data = callback.getCall(0).thisValue;
+		sent_data = callback.getCall(0).thisValue;
 
-			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
-			// Event
-			assert.equal(sent_data.category, "slideshow");
-			assert.equal(sent_data.action, "slide_viewed");
-			assert.equal(sent_data.context.slide_number, 5);
-			assert.equal(sent_data.context.component_id, "123456");
-			assert.equal(sent_data.context.component_name, 'custom-o-tracking');
-			done();
-		}, 10)
-
+		// Event
+		assert.equal(sent_data.category, "slideshow");
+		assert.equal(sent_data.action, "slide_viewed");
+		assert.equal(sent_data.context.slide_number, 5);
+		assert.equal(sent_data.context.component_id, "123456");
+		assert.equal(sent_data.context.component_name, 'custom-o-tracking');
 	});
 
-	it('should listen to a dom event and generate a component_id', function (done) {
+	it('should listen to a dom event and generate a component_id', function () {
 
 		const event = new CustomEvent('oTracking.event', {
 			detail: {
@@ -72,23 +68,20 @@ describe('event', function () {
 			const callback = sinon.spy();
 
 			track_event(e, callback);
-			setTimeout(() => {
-				assert.ok(callback.called, 'Callback not called.');
+			assert.ok(callback.called, 'Callback not called.');
 
-				const sent_data = callback.getCall(0).thisValue;
+			const sent_data = callback.getCall(0).thisValue;
 
-				assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
-				// Event
-				assert.equal(sent_data.category, "video");
-				assert.equal(sent_data.action, "play");
-				assert.equal(sent_data.context.key, 'id');
-				assert.equal(sent_data.context.value, 51234);
-				assert.equal(typeof sent_data.context.component_id, "number");
-				assert.equal(sent_data.context.component_name, "o-tracking");
+			// Event
+			assert.equal(sent_data.category, "video");
+			assert.equal(sent_data.action, "play");
+			assert.equal(sent_data.context.key, 'id');
+			assert.equal(sent_data.context.value, 51234);
+			assert.equal(typeof sent_data.context.component_id, "number");
+			assert.equal(sent_data.context.component_name, "o-tracking");
 
-				done();
-			});
 		});
 
 		document.body.dispatchEvent(event);

--- a/test/events/custom.test.js
+++ b/test/events/custom.test.js
@@ -4,14 +4,16 @@ const assert = require("assert");
 const Queue = require("../../src/javascript/core/queue");
 const settings = require("../../src/javascript/core/settings");
 const send = require("../../src/javascript/core/send");
+const session = require("../../src/javascript/core/session");
 
 describe('event', function () {
 
-	let server;
 	const track_event = require("../../src/javascript/events/custom.js");
 
 	before(function () {
+		session.init();
 		send.init(); // Init the sender.
+
 		//require("../../src/javascript/core").setRootID('rootID'); // Fix the click ID to stop it generating one.
 	});
 

--- a/test/events/link-click.test.js
+++ b/test/events/link-click.test.js
@@ -6,22 +6,20 @@ const Queue = require("../../src/javascript/core/queue");
 const settings = require("../../src/javascript/core/settings");
 const send = require("../../src/javascript/core/send");
 const core = require("../../src/javascript/core");
-const link = require("../../src/javascript/events/link-click.js");
+const link = require("../../src/javascript/events/link-click");
+const session = require("../../src/javascript/core/session");
 
 describe('click', function () {
 
-	let server;
-
 	before(function () {
 		core.setRootID('page_id'); // Fix the click ID to stop it generating one.
+		session.init();
 		send.init(); // Init the sender.
-		server = sinon.fakeServer.create(); // Catch AJAX requests
 	});
 
 	after(function () {
 		new Queue('requests').replace([]);  // Empty the queue
 		settings.destroy('config');  // Empty settings.
-		server.restore();
 	});
 
 	it('should track an external link', function (done) {
@@ -65,4 +63,70 @@ describe('click', function () {
 		}, 10)
 
 	});
+	describe('internal links', function () {
+		let aLink;
+
+		before(function () {
+			aLink = document.createElement('a');
+			aLink.href = location.origin + '/url';
+			aLink.text = "A link to Google's website";
+		});
+
+		it('should store an event for an internal link', function (done) {
+			const event = document.createEvent('HTMLEvents');
+			const callback = sinon.spy();
+			link.init({
+				links: [aLink],
+				event: 'testClick',
+				callback: callback
+			});
+
+			event.initEvent('testClick', true, true);
+			aLink.dispatchEvent(event, true);
+			setTimeout(() => {
+				assert.ok(!callback.called, 'Callback called.');
+				const storedEvent = JSON.parse(localStorage.getItem('o-tracking_links'))[0];
+
+				assert.equal(typeof storedEvent.created_at, 'number')
+				assert.equal(storedEvent.item.category, "link");
+				assert.equal(storedEvent.item.action, "click");
+
+				// Link
+				assert.equal(storedEvent.item.context.link.id, "a/url");
+				assert.equal(storedEvent.item.context.link.source_id, "page_id");
+				assert.equal(storedEvent.item.context.link.href, aLink.href);
+				assert.equal(storedEvent.item.context.link.title, aLink.text);
+				done();
+			}, 10)
+
+		});
+
+		it('should send event for an internal link on new page load', function (done) {
+
+			sinon.stub(core, 'track')
+			// simulates loading of a new page
+			link.init({});
+
+			setTimeout(() => {
+				assert.equal(localStorage.getItem('o-tracking_links'), '[]');
+				assert.ok(core.track.called, 'Callback not called.');
+
+				const sent_data = core.track.getCall(0).args[0];
+
+				// Type
+				assert.equal(sent_data.category, "link");
+				assert.equal(sent_data.action, "click");
+
+				// Link
+				assert.equal(sent_data.context.link.id, "a/url");
+				assert.equal(sent_data.context.link.source_id, "page_id");
+				assert.equal(sent_data.context.link.href, aLink.href);
+				assert.equal(sent_data.context.link.title, aLink.text);
+				core.track.restore();
+				done();
+			}, 10)
+
+		});
+	})
+
 });

--- a/test/events/link-click.test.js
+++ b/test/events/link-click.test.js
@@ -24,8 +24,7 @@ describe('click', function () {
 		server.restore();
 	});
 
-	it('should track an external link', function () {
-		server.respondWith([200, { "Content-Type": "plain/text", "Content-Length": 2 }, "OK"]);
+	it('should track an external link', function (done) {
 
 		const callback = sinon.spy();
 		let sent_data;
@@ -44,24 +43,26 @@ describe('click', function () {
 
 		event.initEvent('testClick', true, true);
 		aLink.dispatchEvent(event, true);
+		setTimeout(() => {
+			assert.ok(callback.called, 'Callback not called.');
 
-		server.respond();
-		assert.ok(callback.called, 'Callback not called.');
+			sent_data = callback.getCall(0).thisValue;
 
-		sent_data = callback.getCall(0).thisValue;
+			// Basics
+			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
-		// Basics
-		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+			// Type
+			assert.equal(sent_data.category, "link");
+			assert.equal(sent_data.action, "click");
+			assert.equal(sent_data.context.root_id, "page_id");
 
-		// Type
-		assert.equal(sent_data.category, "link");
-		assert.equal(sent_data.action, "click");
-		assert.equal(sent_data.context.root_id, "page_id");
+			// Link
+			assert.equal(sent_data.context.link.id, "a/www.google.com");
+			assert.equal(sent_data.context.link.source_id, "page_id");
+			assert.equal(sent_data.context.link.href, aLink.href);
+			assert.equal(sent_data.context.link.title, aLink.text);
+			done();
+		}, 10)
 
-		// Link
-		assert.equal(sent_data.context.link.id, "a/www.google.com");
-		assert.equal(sent_data.context.link.source_id, "page_id");
-		assert.equal(sent_data.context.link.href, aLink.href);
-		assert.equal(sent_data.context.link.title, aLink.text);
 	});
 });

--- a/test/events/page.test.js
+++ b/test/events/page.test.js
@@ -21,7 +21,7 @@ describe('page', function () {
 		settings.destroy('config');  // Empty settings.
 	});
 
-	it('should track a page', function (done) {
+	it('should track a page', function () {
 		const callback = sinon.spy();
 		let sent_data;
 
@@ -29,29 +29,26 @@ describe('page', function () {
 			url: "http://www.ft.com/home/uk"
 		}, callback);
 
-		setTimeout(() => {
-			assert.ok(callback.called, 'Callback not called.');
+		assert.ok(callback.called, 'Callback not called.');
 
-			sent_data = callback.getCall(0).thisValue;
-			// Basics
-			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
-			assert.deepEqual(Object.keys(sent_data.context), ["id","root_id","url","referrer"]);
+		sent_data = callback.getCall(0).thisValue;
+		// Basics
+		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+		assert.deepEqual(Object.keys(sent_data.context), ["id","root_id","url","referrer"]);
 
-			// Type
-			assert.equal(sent_data.category, "page");
-			assert.equal(sent_data.action, "view");
+		// Type
+		assert.equal(sent_data.category, "page");
+		assert.equal(sent_data.action, "view");
 
-			// Page
-			assert.equal(sent_data.context.url, "http://www.ft.com/home/uk");
-			/*eslint-disable*/
-			assert.ok((sent_data.context.referrer != null), "referrer is invalid. " + sent_data.context.referrer);
-			/*eslint-enable*/
-			done();
-		}, 10)
+		// Page
+		assert.equal(sent_data.context.url, "http://www.ft.com/home/uk");
+		/*eslint-disable*/
+		assert.ok((sent_data.context.referrer != null), "referrer is invalid. " + sent_data.context.referrer);
+		/*eslint-enable*/
 
 	});
 
-	it('should assign a unique root_id for each page', function (done) {
+	it('should assign a unique root_id for each page', function () {
 
 		const callback = sinon.spy();
 		const callback2 = sinon.spy();
@@ -61,21 +58,16 @@ describe('page', function () {
 		page({
 			url: "http://www.ft.com/home/uk"
 		}, callback);
-		setTimeout(() => {
-			assert.ok(callback.called, 'Callback not called.');
+		assert.ok(callback.called, 'Callback not called.');
 
-			page1_root_id = callback.getCall(0).thisValue.context.root_id;
+		page1_root_id = callback.getCall(0).thisValue.context.root_id;
 
-			page({
-				url: "http://www.ft.com/home/uk"
-			}, callback2);
-			setTimeout(() => {
-				assert.ok(callback2.called, 'Callback not called.');
+		page({
+			url: "http://www.ft.com/home/uk"
+		}, callback2);
+		assert.ok(callback2.called, 'Callback not called.');
 
-				page2_root_id = callback2.getCall(0).thisValue.context.root_id;
-				assert.notEqual(page1_root_id, page2_root_id, 'root_id is not unique');
-				done();
-			}, 10);
-		}, 10);
+		page2_root_id = callback2.getCall(0).thisValue.context.root_id;
+		assert.notEqual(page1_root_id, page2_root_id, 'root_id is not unique');
 	});
 });

--- a/test/events/page.test.js
+++ b/test/events/page.test.js
@@ -43,7 +43,9 @@ describe('page', function () {
 
 			// Page
 			assert.equal(sent_data.context.url, "http://www.ft.com/home/uk");
+			/*eslint-disable*/
 			assert.ok((sent_data.context.referrer != null), "referrer is invalid. " + sent_data.context.referrer);
+			/*eslint-enable*/
 			done();
 		}, 10)
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -6,18 +6,15 @@ const Queue = require("../src/javascript/core/queue");
 
 describe('main', function () {
 
-	let server;
 	const oTracking = require("../main.js");
 	let root_id;
 
 	before(function () {
 		new Queue('requests').replace([]);  // Empty the queue as PhantomJS doesn't always start fresh.
 		settings.destroy('config');  // Empty settings.
-		server = sinon.fakeServer.create(); // Catch AJAX requests
 	});
 
 	after(function () {
-		server.restore();
 	});
 
 	it('should configure itself from the DOM if no options are present', function() {
@@ -44,7 +41,7 @@ describe('main', function () {
 		oTracking.destroy();
 	});
 
-	it('should track a page', function () {
+	it('should track a page', function (done) {
 		oTracking.init({
 			context: {
 				product: 'desktop'
@@ -56,7 +53,6 @@ describe('main', function () {
 
 		//console.log('cookies', document.cookie);
 
-		server.respondWith([200, { "Content-Type": "plain/text", "Content-Length": 2 }, "OK"]);
 
 		const callback = sinon.spy();
 		let sent_data;
@@ -65,35 +61,37 @@ describe('main', function () {
 			url: 'http://www.ft.com/cms/s/0/576f5f1c-0509-11e5-9627-00144feabdc0.html'
 		}, callback);
 
-		server.respond();
-		assert.ok(callback.called, 'Callback not called.');
+		setTimeout(() => {
 
-		sent_data = callback.getCall(0).thisValue;
+			assert.ok(callback.called, 'Callback not called.');
 
-		root_id = sent_data.context.root_id;
+			sent_data = callback.getCall(0).thisValue;
 
-		// Basics
-		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+			root_id = sent_data.context.root_id;
 
-		// Meta
-		assert.equal(sent_data.system.api_key, "qUb9maKfKbtpRsdp0p2J7uWxRPGJEP");
-		assert.ok(sent_data.system.version.match(/\d+\.\d+.\d+/));
-		assert.equal(sent_data.system.source, "o-tracking");
+			// Basics
+			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
-		// Type
-		assert.equal(sent_data.category, "page");
-		assert.equal(sent_data.action, "view");
+			// Meta
+			assert.equal(sent_data.system.api_key, "qUb9maKfKbtpRsdp0p2J7uWxRPGJEP");
+			assert.ok(sent_data.system.version.match(/\d+\.\d+.\d+/));
+			assert.equal(sent_data.system.source, "o-tracking");
 
-		// User
-		assert.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
+			// Type
+			assert.equal(sent_data.category, "page");
+			assert.equal(sent_data.action, "view");
 
-		// Page
-		assert.equal(sent_data.context.url, "http://www.ft.com/cms/s/0/576f5f1c-0509-11e5-9627-00144feabdc0.html");
-		assert.equal(sent_data.context.product, "desktop");
+			// User
+			assert.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
+
+			// Page
+			assert.equal(sent_data.context.url, "http://www.ft.com/cms/s/0/576f5f1c-0509-11e5-9627-00144feabdc0.html");
+			assert.equal(sent_data.context.product, "desktop");
+			done();
+		}, 10);
 	});
 
-	it('should track an event', function () {
-		server.respondWith([200, { "Content-Type": "plain/text", "Content-Length": 2 }, "OK"]);
+	it('should track an event', function (done) {
 
 		const callback = sinon.spy();
 		let sent_data;
@@ -106,29 +104,31 @@ describe('main', function () {
 			}
 		}), callback);
 
-		server.respond();
-		assert.ok(callback.called, 'Callback not called.');
+		setTimeout(() => {
+			assert.ok(callback.called, 'Callback not called.');
 
-		sent_data = callback.getCall(0).thisValue;
 
-		// Basics
-		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+			sent_data = callback.getCall(0).thisValue;
 
-		// Type
-		assert.equal(sent_data.category, "video");
-		assert.equal(sent_data.action, "play");
-		assert.equal(sent_data.context.component_id, "123456");
+			// Basics
+			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
-		// User
-		assert.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
+			// Type
+			assert.equal(sent_data.category, "video");
+			assert.equal(sent_data.action, "play");
+			assert.equal(sent_data.context.component_id, "123456");
 
-		// Page
-		assert.equal(sent_data.context.root_id, root_id);
-		assert.equal(sent_data.context.product, "desktop");
+			// User
+			assert.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
+
+			// Page
+			assert.equal(sent_data.context.root_id, root_id);
+			assert.equal(sent_data.context.product, "desktop");
+			done();
+		}, 10)
 	});
 
-	it('should not mutate init config', function () {
-		server.respondWith([200, { "Content-Type": "plain/text", "Content-Length": 2 }, "OK"]);
+	it('should not mutate init config', function (done) {
 
 		const callback1 = sinon.spy();
 		const callback2 = sinon.spy();
@@ -139,24 +139,26 @@ describe('main', function () {
 			my_key: "my_val"
 		}, callback1);
 
-		server.respond();
-		assert.ok(callback1.called, 'Callback not called.');
+		setTimeout(() => {
+			assert.ok(callback1.called, 'Callback not called.');
 
-		sent_data1 = callback1.getCall(0).thisValue;
-		assert.equal(sent_data1.context.my_key, "my_val");
+			sent_data1 = callback1.getCall(0).thisValue;
+			assert.equal(sent_data1.context.my_key, "my_val");
 
-		// Track another page
-		oTracking.page({}, callback2);
+			// Track another page
+			oTracking.page({}, callback2);
+			setTimeout(() => {
+				assert.ok(callback2.called, 'Callback not called.');
 
-		server.respond();
-		assert.ok(callback2.called, 'Callback not called.');
-
-		// Ensure vars from the first track don't leak into the second
-		sent_data2 = callback2.getCall(0).thisValue;
-		assert.equal(sent_data2.context.my_key, undefined);
+				// Ensure vars from the first track don't leak into the second
+				sent_data2 = callback2.getCall(0).thisValue;
+				assert.equal(sent_data2.context.my_key, undefined);
+				done();
+			}, 10)
+		}, 10)
 	});
 
-	it('should allow system properties to be set on init', function () {
+	it('should allow system properties to be set on init', function (done) {
 		oTracking.destroy();
 
 		oTracking.init({
@@ -166,26 +168,26 @@ describe('main', function () {
 			}
 		});
 
-		server.respondWith([200, { "Content-Type": "plain/text", "Content-Length": 2 }, "OK"]);
 
 		const callback = sinon.spy();
 		let sent_data;
 
 		oTracking.page({}, callback);
 
-		server.respond();
-		assert.ok(callback.called, 'Callback not called.');
+		setTimeout(() => {
+			assert.ok(callback.called, 'Callback not called.');
 
-		sent_data = callback.getCall(0).thisValue;
+			sent_data = callback.getCall(0).thisValue;
 
-		assert.equal(sent_data.system.environment, "prod");
-		assert.equal(sent_data.system.is_live, true);
+			assert.equal(sent_data.system.environment, "prod");
+			assert.equal(sent_data.system.is_live, true);
+			done();
+		}, 10)
 	});
 
 	it('should cope with a huge queue as a bug from a previous version', function () {
 		oTracking.destroy();
 
-		let server = sinon.fakeServer.create(); // Catch AJAX requests
 		let queue = new Queue('requests');
 
 		for (let i=0; i<1000; i++) {
@@ -194,9 +196,7 @@ describe('main', function () {
 
 		queue.save();
 
-		server.respondWith([200, { "Content-Type": "plain/text", "Content-Length": 2 }, "OK"]);
 		oTracking.init({ system: { environment: 'prod', is_live: true } });
-		server.respond();
 
 		// Refresh our queue as it's kept in memory
 		queue = new Queue('requests');

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -172,7 +172,7 @@ describe('main', function () {
 
 		let queue = new Queue('requests');
 
-		for (let i=0; i<1000; i++) {
+		for (let i=0; i<201; i++) {
 			queue.add({});
 		}
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -41,7 +41,7 @@ describe('main', function () {
 		oTracking.destroy();
 	});
 
-	it('should track a page', function (done) {
+	it('should track a page', function () {
 		oTracking.init({
 			context: {
 				product: 'desktop'
@@ -51,9 +51,6 @@ describe('main', function () {
 			}
 		});
 
-		//console.log('cookies', document.cookie);
-
-
 		const callback = sinon.spy();
 		let sent_data;
 
@@ -61,37 +58,33 @@ describe('main', function () {
 			url: 'http://www.ft.com/cms/s/0/576f5f1c-0509-11e5-9627-00144feabdc0.html'
 		}, callback);
 
-		setTimeout(() => {
+		assert.ok(callback.called, 'Callback not called.');
 
-			assert.ok(callback.called, 'Callback not called.');
+		sent_data = callback.getCall(0).thisValue;
 
-			sent_data = callback.getCall(0).thisValue;
+		root_id = sent_data.context.root_id;
 
-			root_id = sent_data.context.root_id;
+		// Basics
+		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
-			// Basics
-			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+		// Meta
+		assert.equal(sent_data.system.api_key, "qUb9maKfKbtpRsdp0p2J7uWxRPGJEP");
+		assert.ok(sent_data.system.version.match(/\d+\.\d+.\d+/));
+		assert.equal(sent_data.system.source, "o-tracking");
 
-			// Meta
-			assert.equal(sent_data.system.api_key, "qUb9maKfKbtpRsdp0p2J7uWxRPGJEP");
-			assert.ok(sent_data.system.version.match(/\d+\.\d+.\d+/));
-			assert.equal(sent_data.system.source, "o-tracking");
+		// Type
+		assert.equal(sent_data.category, "page");
+		assert.equal(sent_data.action, "view");
 
-			// Type
-			assert.equal(sent_data.category, "page");
-			assert.equal(sent_data.action, "view");
+		// User
+		assert.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
 
-			// User
-			assert.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
-
-			// Page
-			assert.equal(sent_data.context.url, "http://www.ft.com/cms/s/0/576f5f1c-0509-11e5-9627-00144feabdc0.html");
-			assert.equal(sent_data.context.product, "desktop");
-			done();
-		}, 10);
+		// Page
+		assert.equal(sent_data.context.url, "http://www.ft.com/cms/s/0/576f5f1c-0509-11e5-9627-00144feabdc0.html");
+		assert.equal(sent_data.context.product, "desktop");
 	});
 
-	it('should track an event', function (done) {
+	it('should track an event', function () {
 
 		const callback = sinon.spy();
 		let sent_data;
@@ -104,31 +97,28 @@ describe('main', function () {
 			}
 		}), callback);
 
-		setTimeout(() => {
-			assert.ok(callback.called, 'Callback not called.');
+		assert.ok(callback.called, 'Callback not called.');
 
 
-			sent_data = callback.getCall(0).thisValue;
+		sent_data = callback.getCall(0).thisValue;
 
-			// Basics
-			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+		// Basics
+		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
-			// Type
-			assert.equal(sent_data.category, "video");
-			assert.equal(sent_data.action, "play");
-			assert.equal(sent_data.context.component_id, "123456");
+		// Type
+		assert.equal(sent_data.category, "video");
+		assert.equal(sent_data.action, "play");
+		assert.equal(sent_data.context.component_id, "123456");
 
-			// User
-			assert.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
+		// User
+		assert.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
 
-			// Page
-			assert.equal(sent_data.context.root_id, root_id);
-			assert.equal(sent_data.context.product, "desktop");
-			done();
-		}, 10)
+		// Page
+		assert.equal(sent_data.context.root_id, root_id);
+		assert.equal(sent_data.context.product, "desktop");
 	});
 
-	it('should not mutate init config', function (done) {
+	it('should not mutate init config', function () {
 
 		const callback1 = sinon.spy();
 		const callback2 = sinon.spy();
@@ -139,26 +129,21 @@ describe('main', function () {
 			my_key: "my_val"
 		}, callback1);
 
-		setTimeout(() => {
-			assert.ok(callback1.called, 'Callback not called.');
+		assert.ok(callback1.called, 'Callback not called.');
 
-			sent_data1 = callback1.getCall(0).thisValue;
-			assert.equal(sent_data1.context.my_key, "my_val");
+		sent_data1 = callback1.getCall(0).thisValue;
+		assert.equal(sent_data1.context.my_key, "my_val");
 
-			// Track another page
-			oTracking.page({}, callback2);
-			setTimeout(() => {
-				assert.ok(callback2.called, 'Callback not called.');
+		// Track another page
+		oTracking.page({}, callback2);
+		assert.ok(callback2.called, 'Callback not called.');
 
-				// Ensure vars from the first track don't leak into the second
-				sent_data2 = callback2.getCall(0).thisValue;
-				assert.equal(sent_data2.context.my_key, undefined);
-				done();
-			}, 10)
-		}, 10)
+		// Ensure vars from the first track don't leak into the second
+		sent_data2 = callback2.getCall(0).thisValue;
+		assert.equal(sent_data2.context.my_key, undefined);
 	});
 
-	it('should allow system properties to be set on init', function (done) {
+	it('should allow system properties to be set on init', function () {
 		oTracking.destroy();
 
 		oTracking.init({
@@ -174,15 +159,12 @@ describe('main', function () {
 
 		oTracking.page({}, callback);
 
-		setTimeout(() => {
-			assert.ok(callback.called, 'Callback not called.');
+		assert.ok(callback.called, 'Callback not called.');
 
-			sent_data = callback.getCall(0).thisValue;
+		sent_data = callback.getCall(0).thisValue;
 
-			assert.equal(sent_data.system.environment, "prod");
-			assert.equal(sent_data.system.is_live, true);
-			done();
-		}, 10)
+		assert.equal(sent_data.system.environment, "prod");
+		assert.equal(sent_data.system.is_live, true);
 	});
 
 	it('should cope with a huge queue as a bug from a previous version', function () {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,4 @@
-'use strict';
-
+/* global sinon*/
 const transports = require('../src/javascript/core/transports')
 let willError = false;
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,6 @@
 /* global sinon*/
-const transports = require('../src/javascript/core/transports')
+const transports = require('../src/javascript/core/transports');
+
 let willError = false;
 
 module.exports.mockTransport = function () {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const transports = require('../src/javascript/core/transports')
+let willError = false;
+
+module.exports.mockTransport = function () {
+	transports.mock = function () {
+		return {
+			send: sinon.spy(),
+			complete: function (callback) {
+				if (willError) {
+					willError = false;
+					callback(new Error('mock error'));
+				} else {
+					callback();
+				}
+			}
+		};
+	}
+};
+
+module.exports.unmockTransport = function () {
+	transports.mock = null;
+};
+
+module.exports.errorNextSend = function () {
+	willError = true;
+}
+
+// for the vast majority of tests we want to use a mock transport
+// so we setup the mock globally here
+module.exports.mockTransport();


### PR DESCRIPTION
As part of this I've stopped passing anything in to the on complete callback. It's not documented what gets passed into this callback by o-tracking (and it varies depending on whether the transport is image or XHR anyway) so I think it's, if not necessarily safe, technically fine to stop passing anything in. Better might be to return a Promise, resolved or rejected on request completion/error. Depending on how careful we want to be around people's use of undocumented parameters passed to callback this may necessitate a major release, but would be a step forward worth making I think.