### PR TITLE
cookies on sub-domain

### DIFF
--- a/src/javascript/core/user.js
+++ b/src/javascript/core/user.js
@@ -46,6 +46,7 @@ function migrate_across_domains(store, user_id) {
 
 	// Expire the cookie on the (sub)domain
 	window.document.cookie = 'spoor-id=0;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/;';
+	window.document.cookie = 'spoor-id=0;expires=Thu, 01 Jan 1970 00:00:00 GMT;';
 	// Re-set the cookie on the  root domain
 	store.write(proper_id);
 


### PR DESCRIPTION
Punt on a fix for the issue where we're still seeing spoor-id cookies set against subdomains.

- Don't think cookies are this strict, but worth seeing if dropping the cookie with and without a path fixes the issue.