### PR TITLE
Cookie storage bug

### DIFF
--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -89,7 +89,7 @@ const Store = function (name, config) {
 			for (i = 0; i < cookies.length; i = i + 1) {
 				cookie = cookies[i].replace(/^\s+|\s+$/g, '');
 				if (cookie.indexOf(name) === 0) {
-					return cookie.substring(name.length, cookie.length);
+					return utils.decode(cookie.substring(name.length, cookie.length));
 				}
 			}
 

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -102,6 +102,20 @@ function encode(str) {
 	}
 }
 
+/**
+ * URL decode a string.
+ * @param {string} str - The string to be decoded.
+ *
+ * @return {string} The decoded string.
+ */
+function decode(str) {
+	if (window.decodeURIComponent) {
+		return window.decodeURIComponent(str);
+	} else {
+		return window.unescape(str);
+	}
+}
+
 /*
  * Utility to add event listeners.
  *
@@ -204,6 +218,7 @@ module.exports = {
 	isUndefined: is,
 	merge: merge,
 	encode: encode,
+	decode: decode,
 	guid: cuid,
 	addEvent: addEvent,
 	broadcast: broadcast,

--- a/test/core/store.test.js
+++ b/test/core/store.test.js
@@ -36,4 +36,15 @@ describe('Core.Store', function () {
 		});
 	});
 
+    describe('cookies', function () {
+        it('should store an array of values', function () {
+            let cookie_store = new Store('test-cookies', { storage: 'cookie' });
+
+            cookie_store.write(['one', 'two']);
+
+            cookie_store = new Store('test-cookies', { storage: 'cookie' });
+            assert.deepEqual(cookie_store.read(), ['one', 'two']);
+        });
+    });
+
 });


### PR DESCRIPTION
- Forgot to decode values in cookies, they're set as encoded strings
- Likely a fix for https://github.com/Financial-Times/o-tracking/issues/81 too