### PR TITLE
only init listeners on init, not on load

### DIFF
--- a/main.js
+++ b/main.js
@@ -165,7 +165,8 @@ Tracking.prototype.init = function(config) {
 			}
 		}});
 	}
-
+	this.event.init();
+	this.page.init();
 	this.initialised = true;
 	return this;
 };

--- a/src/javascript/events/custom.js
+++ b/src/javascript/events/custom.js
@@ -218,6 +218,9 @@ function _generateHash(str) {
 	return h >>> 0;
 }
 
-utils.addEvent(window, 'oTracking.event', event);
+
 
 module.exports = event;
+module.exports.init = function () {
+	utils.addEvent(window, 'oTracking.event', event);
+};

--- a/src/javascript/events/link-click.js
+++ b/src/javascript/events/link-click.js
@@ -264,9 +264,8 @@ function init(config) {
 			}
 		});
 	}
+	utils.addEvent(window, 'oTracking.link', track);
 }
-
-utils.addEvent(window, 'oTracking.link', track);
 
 module.exports = {
 	init: init,

--- a/src/javascript/events/page-view.js
+++ b/src/javascript/events/page-view.js
@@ -54,6 +54,10 @@ function page(config, callback) {
 function listener(e) {
 	page(e.detail);
 }
-utils.addEvent(window, 'oTracking.page', listener);
+
+
 
 module.exports = page;
+module.exports.init = function () {
+	utils.addEvent(window, 'oTracking.page', listener);
+};


### PR DESCRIPTION
The current implementation - where listeners are added on load - means that we can't turn o-tracking fully off with a flag as it still tries to send requests to spoor when something on the page fires an oTracking event. This throws an error because o-tracking hasn't been initialised and configured

```
Uncaught TypeError: Cannot read property 'read' of undefinedgetSession @ session.js:43track @ core.js:97event @ custom.js:67module.exports @ dispatchCustomEvent.js:16(anonymous function) @ navigation-timing.js:98setTimeout (async)load @ navigation-timing.js:21
```

@markstephens 