### PR TITLE
As a last resort, parse a spoor-id value from query param

### DIFF
--- a/src/javascript/core/user.js
+++ b/src/javascript/core/user.js
@@ -61,6 +61,18 @@ function migrate_across_domains(store, user_id) {
 }
 
 /**
+ * Parse a user ID from a URL query param
+ * @param  {string} name   key name
+ * @param  {string} search URL search param (e.g. '?spoor-id=xxx&b=c')
+ * @return {string}        parsed ID (e.g. 'xxx')
+ */
+function userIDFromQuery(name, query) {
+	const regexp = new RegExp(`(?:&|\\?)${name}=([^&]+)`);
+	const matches = (query || '').match(regexp);
+	return (matches || [])[1];
+}
+
+/**
  * Init
  *
  * @param {String|Object} value The value of a userID to use or configuration object.
@@ -87,6 +99,10 @@ function init(value) {
 	}
 
 	if (!userID) {
+		userID = userIDFromQuery(config.name, location.search);
+	}
+
+	if (!userID) {
 		userID = utils.guid();
 	}
 
@@ -102,5 +118,6 @@ function destroy() {
 module.exports = {
 	init: init,
 	userID: function () { return userID; },
+	userIDFromQuery,
 	destroy: destroy
 };

--- a/test/core/user.test.js
+++ b/test/core/user.test.js
@@ -49,4 +49,22 @@ describe('Core.User', function () {
 		});
 	});
 
+	describe('user ID from query param', function () {
+		it('should parse a simple query', function () {
+			assert.equal(User.userIDFromQuery('spoor-id', '?spoor-id=abc'), 'abc');
+		});
+
+		it('should parse the second of three params', function () {
+			assert.equal(User.userIDFromQuery('spoor-id', '?a=b&spoor-id=abc&y=z'), 'abc');
+		});
+
+		it('should ignore empty param', function () {
+			assert.equal(User.userIDFromQuery('spoor-id', '?spoor-id='), undefined);
+		});
+
+		it('should handle special chars', function () {
+			assert.equal(User.userIDFromQuery('spoor-id', '?spoor-id=ab^@£$()£$-_9012&b=c'), 'ab^@£$()£$-_9012');
+		});
+	});
+
 });


### PR DESCRIPTION
Some apps can't read cookies, so create their own device identifiers and pass them as a query param when launching FT.com URLs. https://jira.ft.com/browse/DTPCA-48 implements reading a `spoor-id` from URL query parameter. 

However, if an app passes a `spoor-id` query param to a domain with o-tracking installed, o-tracking will by default create a new identifier if one doesn't already exist as a cookie or in localStorage. Hence, if none is yet defined, read from query param so that only a single identifier is set for this device and sent to Spoor.
