### PR TITLE
Only allow callbacks that are functions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+.PHONY: test
+test:
+	npm test
 
 whitesource.config.json:
 	echo '{ "apiKey": "$(WHITESOURCE_API_KEY)", "checkPolicies":true,"productName":"NGDA","projectName":"o_tracking", "devDep": "false"}' > $@;

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -122,6 +122,9 @@ function add(request) {
 function run(callback) {
 	if (utils.isUndefined(callback)) {
 		callback = function () {};
+	} else if (typeof(callback) !== 'function') {
+		utils.log(`o-tracking error: 'callback' is defined, but is not a function.`)
+		callback = function () {};
 	}
 
     // Investigate queue lengths bug

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -122,9 +122,6 @@ function add(request) {
 function run(callback) {
 	if (utils.isUndefined(callback)) {
 		callback = function () {};
-	} else if (typeof(callback) !== 'function') {
-		utils.log(`o-tracking error: 'callback' is defined, but is not a function.`)
-		callback = function () {};
 	}
 
     // Investigate queue lengths bug
@@ -196,7 +193,9 @@ function init() {
 	}
 
 	// If any tracking calls are made whilst offline, try sending them the next time the device comes online
-	utils.addEvent(window, 'online', run);
+	utils.addEvent(window, 'online', function() {
+		run();
+	});
 
 	// On startup, try sending any requests queued from a previous session.
 	run();


### PR DESCRIPTION
Something seems to be somehow calling o-tracking/send.js `run(callback)` with a `callback` that is an `Event` of `type:"online"`. 

![image](https://cloud.githubusercontent.com/assets/224547/23463441/6a37e4e0-fe89-11e6-9908-4fe717859d0d.png)

I reproduced this in the `next-article` app by going offline (switching off wifi), waiting a minute, then coming back online.

I tried to find what was setting `callback` to an `Event`, with no success. So the best I can do for now is guard against any non-function callbacks.

This will hopefully reduce the "t is not a function" errors in [sentry](https://sentry.io/nextftcom/frontend/?query=is%3Aunresolved+t+is+not+a+function).

![image](https://cloud.githubusercontent.com/assets/224547/23463674/52a37c58-fe8a-11e6-9a9e-ecaf533c7b4c.png)
