### PR TITLE
Securedrop stop tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "private": true,
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start karma.conf.js"
+    "test": "./node_modules/karma/bin/karma start karma.conf.js",
+    "test-watch": "node node_modules/karma/bin/karma start --browsers=Chrome --single-run=false --auto-watch"
   },
   "devDependencies": {
     "babelify": "^6.1.3",

--- a/src/javascript/events/click.js
+++ b/src/javascript/events/click.js
@@ -121,9 +121,8 @@ const getEventProperties = event => {
 
 // Controller for handling click events
 const handleClickEvent = eventData => (clickEvent, clickElement) => {
-	//we don't want to track clicks to the securedrop anonymous service
-	if (typeof clickElement.href !== "undefined" &&
-			clickElement.href.match(".*ft\.com.*/securedrop")) return;
+	//we don't want to track clicks to anonymous services like securedrop
+	if (clickElement.getAttribute("data-o-tracking-do-not-track") === "true") return;
 	const context = getEventProperties(clickEvent);
 	context.domPathTokens = getTrace(clickElement);
 	context.url = window.document.location.href || null;

--- a/src/javascript/events/click.js
+++ b/src/javascript/events/click.js
@@ -121,6 +121,9 @@ const getEventProperties = event => {
 
 // Controller for handling click events
 const handleClickEvent = eventData => (clickEvent, clickElement) => {
+	//we don't want to track clicks to the securedrop anonymous service
+	if (typeof clickElement.href !== "undefined" &&
+			clickElement.href.match(".*ft\.com.*/securedrop")) return;
 	const context = getEventProperties(clickEvent);
 	context.domPathTokens = getTrace(clickElement);
 	context.url = window.document.location.href || null;

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -37,14 +37,17 @@ describe('click', function () {
 
 		sinon.spy(core, 'track');
 
-		click.init("blah", "div");
+		click.init("blah");
 
-		const aDiv = document.createElement('div');
-		//const event = document.createEvent('HTMLEvents');
+		const aLinkToGoogle = document.createElement('a');
 
-		aDiv.href = "http://www.google.com";
-		aDiv.text = "A link to Google's website";
-		aDiv.id = "anchor";
+		aLinkToGoogle.href = "http://www.google.com";
+		aLinkToGoogle.text = "A link to Google's website";
+		aLinkToGoogle.id = "anchorA";
+
+		aLinkToGoogle.addEventListener('click', function(e){
+			e.preventDefault();
+		}); //we don't want the browser to follow click in test
 
 		var event = new MouseEvent('click', {
 			'view': window,
@@ -52,8 +55,8 @@ describe('click', function () {
 			'cancelable': true
 		});
 
-		document.body.appendChild(aDiv);
-		aDiv.dispatchEvent(event, true);
+		document.body.appendChild(aLinkToGoogle);
+		aLinkToGoogle.dispatchEvent(event, true);
 
 		setTimeout(() => {
 
@@ -62,7 +65,7 @@ describe('click', function () {
 			core.track.restore();
 			done();
 
-		}, 100);
+		}, 10);
 
 	});
 
@@ -70,13 +73,17 @@ describe('click', function () {
 
 		sinon.spy(core, 'track');
 
-		click.init("blah","div");
+		click.init("blah");
 
-		const aDiv = document.createElement('div');
+		const aLinkToSecuredrop = document.createElement('a');
 
-		aDiv.href = "https://www.ft.com/securedrop";
-		aDiv.text = "A link to securedrop";
-		aDiv.id = "anchor";
+		aLinkToSecuredrop.href = "https://www.ft.com/securedrop";
+		aLinkToSecuredrop.text = "A link to securedrop";
+		aLinkToSecuredrop.id = "anchor";
+
+		aLinkToSecuredrop.addEventListener('click', function(e){
+			e.preventDefault();
+		}); //we don't want the browser to follow click in test
 
 		var event = new MouseEvent('click', {
 			'view': window,
@@ -84,8 +91,8 @@ describe('click', function () {
 			'cancelable': true
 		});
 
-		document.body.appendChild(aDiv);
-		aDiv.dispatchEvent(event, true);
+		document.body.appendChild(aLinkToSecuredrop);
+		aLinkToSecuredrop.dispatchEvent(event, true);
 
 		setTimeout(() => {
 
@@ -94,7 +101,7 @@ describe('click', function () {
 			core.track.restore();
 			done();
 
-		}, 100);
+		}, 10);
 
 	});
 

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -78,7 +78,8 @@ describe('click', function () {
 
 		aLinkToSecuredrop.href = "https://www.ft.com/securedrop";
 		aLinkToSecuredrop.text = "A link to securedrop";
-		aLinkToSecuredrop.id = "anchor";
+		aLinkToSecuredrop.id = "anchorB";
+		aLinkToSecuredrop.setAttribute("data-o-tracking-do-not-track", "true");
 
 		aLinkToSecuredrop.addEventListener('click', function(e){
 			e.preventDefault();

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -7,6 +7,7 @@ const send = require("../../src/javascript/core/send");
 const core = require("../../src/javascript/core");
 const click = require("../../src/javascript/events/click");
 const session = require("../../src/javascript/core/session");
+const utils = require("../../src/javascript/utils");
 
 describe('click', function () {
 
@@ -14,6 +15,17 @@ describe('click', function () {
 		core.setRootID('page_id'); // Fix the click ID to stop it generating one.
 		session.init();
 		send.init(); // Init the sender.
+
+		const config = {
+			context: {
+				product: 'desktop'
+			},
+			user: {
+				user_id: '123456'
+			}
+		};
+
+		settings.set("config",config);
 	});
 
 	after(function () {
@@ -21,111 +33,69 @@ describe('click', function () {
 		settings.destroy('config');  // Empty settings.
 	});
 
-	it('should track an external link', function (done) {
+	it('should track an event for a click', function (done) {
 
-		const callback = sinon.spy();
-		let sent_data;
+		sinon.spy(core, 'track');
 
-		const aLink = document.createElement('a');
-		const event = document.createEvent('HTMLEvents');
+		click.init("blah", "div");
 
-		aLink.href = "http://www.google.com";
-		aLink.text = "A link to Google's website";
+		const aDiv = document.createElement('div');
+		//const event = document.createEvent('HTMLEvents');
 
-		click.init({
-			links: [aLink],
-			event: 'testClick',
-			callback: callback
+		aDiv.href = "http://www.google.com";
+		aDiv.text = "A link to Google's website";
+		aDiv.id = "anchor";
+
+		var event = new MouseEvent('click', {
+			'view': window,
+			'bubbles': true,
+			'cancelable': true
 		});
 
-		event.initEvent('testClick', true, true);
-		aLink.dispatchEvent(event, true);
+		document.body.appendChild(aDiv);
+		aDiv.dispatchEvent(event, true);
+
 		setTimeout(() => {
-			assert.ok(callback.called, 'Callback not called.');
 
-			sent_data = callback.getCall(0).thisValue;
+			assert.equal(core.track.calledOnce, true, "click event tracked");
 
-			// Basics
-			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
-
-			// Type
-			assert.equal(sent_data.category, "link");
-			assert.equal(sent_data.action, "click");
-			assert.equal(sent_data.context.root_id, "page_id");
-
-			// Link
-			assert.equal(sent_data.context.link.id, "a/www.google.com");
-			assert.equal(sent_data.context.link.source_id, "page_id");
-			assert.equal(sent_data.context.link.href, aLink.href);
-			assert.equal(sent_data.context.link.title, aLink.text);
+			core.track.restore();
 			done();
-		}, 10);
+
+		}, 100);
 
 	});
-	describe('internal links', function () {
-		let aLink;
 
-		before(function () {
-			aLink = document.createElement('a');
-			aLink.href = location.origin + '/url';
-			aLink.text = "A link to Google's website";
+	it('should not track an event for a securedrop click', function (done) {
+
+		sinon.spy(core, 'track');
+
+		click.init("blah","div");
+
+		const aDiv = document.createElement('div');
+
+		aDiv.href = "https://www.ft.com/securedrop";
+		aDiv.text = "A link to securedrop";
+		aDiv.id = "anchor";
+
+		var event = new MouseEvent('click', {
+			'view': window,
+			'bubbles': true,
+			'cancelable': true
 		});
 
-		it('should store an event for an internal link', function (done) {
-			const event = document.createEvent('HTMLEvents');
-			const callback = sinon.spy();
-			click.init({
-				links: [aLink],
-				event: 'testClick',
-				callback: callback
-			});
+		document.body.appendChild(aDiv);
+		aDiv.dispatchEvent(event, true);
 
-			event.initEvent('testClick', true, true);
-			aLink.dispatchEvent(event, true);
-			setTimeout(() => {
-				assert.ok(!callback.called, 'Callback called.');
-				const storedEvent = JSON.parse(localStorage.getItem('o-tracking_links'))[0];
+		setTimeout(() => {
 
-				assert.equal(typeof storedEvent.created_at, 'number');
-				assert.equal(storedEvent.item.category, "link");
-				assert.equal(storedEvent.item.action, "click");
+			assert.equal(core.track.notCalled, true, "click event not tracked");
 
-				// Link
-				assert.equal(storedEvent.item.context.link.id, "a/url");
-				assert.equal(storedEvent.item.context.link.source_id, "page_id");
-				assert.equal(storedEvent.item.context.link.href, aLink.href);
-				assert.equal(storedEvent.item.context.link.title, aLink.text);
-				done();
-			}, 10);
+			core.track.restore();
+			done();
 
-		});
+		}, 100);
 
-		it('should send event for an internal link on new page load', function (done) {
-
-			sinon.stub(core, 'track');
-			// simulates loading of a new page
-			click.init({});
-
-			setTimeout(() => {
-				assert.equal(localStorage.getItem('o-tracking_links'), '[]');
-				assert.ok(core.track.called, 'Callback not called.');
-
-				const sent_data = core.track.getCall(0).args[0];
-
-				// Type
-				assert.equal(sent_data.category, "link");
-				assert.equal(sent_data.action, "click");
-
-				// Link
-				assert.equal(sent_data.context.link.id, "a/url");
-				assert.equal(sent_data.context.link.source_id, "page_id");
-				assert.equal(sent_data.context.link.href, aLink.href);
-				assert.equal(sent_data.context.link.title, aLink.text);
-				core.track.restore();
-				done();
-			}, 10);
-
-		});
 	});
 
 });

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -7,7 +7,6 @@ const send = require("../../src/javascript/core/send");
 const core = require("../../src/javascript/core");
 const click = require("../../src/javascript/events/click");
 const session = require("../../src/javascript/core/session");
-const utils = require("../../src/javascript/utils");
 
 describe('click', function () {
 
@@ -49,7 +48,7 @@ describe('click', function () {
 			e.preventDefault();
 		}); //we don't want the browser to follow click in test
 
-		var event = new MouseEvent('click', {
+		let event = new MouseEvent('click', {
 			'view': window,
 			'bubbles': true,
 			'cancelable': true
@@ -85,7 +84,7 @@ describe('click', function () {
 			e.preventDefault();
 		}); //we don't want the browser to follow click in test
 
-		var event = new MouseEvent('click', {
+		let event = new MouseEvent('click', {
 			'view': window,
 			'bubbles': true,
 			'cancelable': true


### PR DESCRIPTION
This change is added to support securedrop, after this change any clicks to the securedrop service should be excluded from tracking.