### PR TITLE
Allow tracking settings to be changed after init to allow for changes during the lifetime of a page, merge in device config to tracking calls, and rework core track logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ o-tracking will
 * Automatically pickup ftsession from cookies for you.
 * Page events automatically pick up the url and the referrer.
 
+Events are decorated with config values you pass in via `init()` or `updateConfig()` if they are part of `context`, `user`, or `device` objects. Values passed in as `context` to individual events will override context values from init.
+
 ### Init
 ```js
 {
@@ -193,6 +195,18 @@ o-tracking will
     },
     user: {
         ft_session: "..."
+    },
+    device: {
+        orientation: "..."
+    }
+}
+```
+
+### Updating core configuration
+```js
+{
+    device: {
+        orientation: "..."
     }
 }
 ```
@@ -212,7 +226,7 @@ o-tracking will
 
 ### Event
 
-__Important__: To decide how to name the category and action fields, consider this sentance (square brackets denote that part is optional):
+__Important__: To decide how to name the category and action fields, consider this sentence (square brackets denote that part is optional):
 
 #### A user can {action} a {category}[ with/having a {context}[ to {destination}]]
 

--- a/main.js
+++ b/main.js
@@ -115,33 +115,21 @@ Tracking.prototype.init = function(config) {
 
 	const hasDeclarativeConfig = !!this._getDeclarativeConfigElement();
 
-	if (!(hasDeclarativeConfig || config)) {
-		return this;
-	}
-
 	config = config || {};
 	if (hasDeclarativeConfig) {
 		config = this._getDeclarativeConfig(config);
 	}
 
-	settings.set('config', config);
 	settings.set('version', this.version);
 	settings.set('source', this.source);
 	settings.set('api_key', this.api_key);
 
 	settings.set('page_sent', false);
 
-	// Developer mode
-	if (config.developer) {
-		this.developer(config.developer);
+	// Set up the user from stored - may later be updated by config
+	user.init();
 
-		if (config.noSend) {
-			settings.set('no_send', true);
-		}
-	}
-
-	// User identifier
-	user.init(config.user ? config.user.user_id : null);
+	this.updateConfig(config);
 
 	// Session
 	session.init(config.session);
@@ -153,6 +141,34 @@ Tracking.prototype.init = function(config) {
 	this.page.init();
 	this.initialised = true;
 	return this;
+};
+
+/**
+ * Update the tracking configuration with any state changes. The supplied
+ * config is merged with any existing config; to unset a value, set it as
+ * null or undefined.
+ *
+ * @param {Object} newConfig The configuration object to merge in - see init()
+ * @return {void}
+ */
+Tracking.prototype.updateConfig = function(newConfig) {
+	let config = settings.get('config') || {};
+
+	config = this.utils.merge(config, newConfig);
+	settings.set('config', config);
+
+	// Developer mode
+	if (config.developer) {
+		this.developer(config.developer);
+
+		if (config.noSend) {
+			settings.set('no_send', true);
+		}
+	}
+
+	if (config.user && config.user.user_id) {
+		user.setUser(config.user.user_id);
+	}
 };
 
 /**

--- a/src/javascript/core.js
+++ b/src/javascript/core.js
@@ -86,7 +86,7 @@ function track(config, callback) {
 	// Send it.
 	Send.addAndRun(request);
 
-	return config;
+	return request;
 }
 
 module.exports = {

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -49,7 +49,7 @@ function is(variable, type) {
 }
 
 /**
- * Merge objects together. Will remove 'falsy' values.
+ * Merge objects together. Will remove undefined and null values.
  *
  * @param {Object} target - The original object to merge in to.
  * @param {Object} options - The object to merge into the target. If omitted, will merge target into a new empty Object.

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -12,13 +12,22 @@ describe('Core', function () {
 	const guid_re = /\w{25}/; // cifnulwv2000030ds4avpbm9f
 
 	describe('root_id', function () {
+		let root_id;
+
 		it('should generate a root_id', function () {
-			const root_id = Core.setRootID();
+			root_id = Core.setRootID();
 			assert.ok(root_id.match(guid_re), "'" + root_id + "'.match(" + guid_re + ")");
 		});
 
-		it('should use the root_id given it', function () {
-			assert.equal(Core.setRootID("myroot_id"), "myroot_id");
+		it('should use the previous root_id for subsequent calls', function () {
+			assert.equal(Core.getRootID(), root_id);
+			assert.equal(Core.getRootID(), root_id);
+		});
+
+		it('should change the root_id on request', function () {
+			const new_root_id = Core.setRootID();
+			assert.equal(Core.getRootID(), new_root_id);
+			assert.notEqual(new_root_id, root_id);
 		});
 	});
 
@@ -41,7 +50,7 @@ describe('Core', function () {
 			const callback = sinon.spy();
 			let sent_data;
 
-			Core.setRootID('root_id');
+			const root_id = Core.setRootID();
 			Core.track({
 				category: 'page',
 				action: 'view',
@@ -62,11 +71,11 @@ describe('Core', function () {
 			// Context
 			assert.deepEqual(Object.keys(sent_data.context), ["id","root_id","url"]);
 			assert.ok(guid_re.test(sent_data.context.id), "Request ID is invalid. " + sent_data.context.id);
-			assert.equal(sent_data.context.root_id, "root_id");
+			assert.equal(sent_data.context.root_id, root_id);
 			assert.equal(sent_data.context.url, "http://www.ft.com/home/uk");
 
 			// User
-			assert.deepEqual(Object.keys(sent_data.user), ["user_id"]);
+			assert.deepEqual(Object.keys(sent_data.user), ["passport_id","ft_session","user_id"]);
 			assert.equal(sent_data.user.user_id, "userID");
 
 			// Device

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -11,7 +11,6 @@ const session = require("../../src/javascript/core/session");
 describe('click', function () {
 
 	before(function () {
-		core.setRootID('page_id'); // Fix the click ID to stop it generating one.
 		session.init();
 		send.init(); // Init the sender.
 

--- a/test/events/custom.test.js
+++ b/test/events/custom.test.js
@@ -13,8 +13,6 @@ describe('event', function () {
 	before(function () {
 		session.init();
 		send.init(); // Init the sender.
-
-		//require("../../src/javascript/core").setRootID('rootID'); // Fix the click ID to stop it generating one.
 	});
 
 	after(function () {


### PR DESCRIPTION
These are the base changes required for the app and its single-page model to work with o-tracking; allowing the configuration to be updated without recreating the object means that user etc state can change and be reflected in tracking calls.

Adding context, device, and user from the base config consistently to tracking calls simplifies the code, and means device details can easily be supplied for the first time (we assume this is why Next is currently shoehorning device properties into the user object?).

More than I intended to do but far less than I wanted to do after I started!  Will annotate some parts of the PR...