### PR TITLE
Bump the version number

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ const send = require('./src/javascript/core/send');
  * The version of the tracking module.
  * @type {string}
  */
-const version = '1.1.15';
+const version = '1.2.1';
 /**
  * The source of this event.
  * @type {string}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "o-tracking",
   "description": "This module should be included on your product to make sending tracking requests to the Spoor API easy.",
-  "version": "1.1.15",
+  "version": "1.2.1",
   "main": "main.js",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Oops.

(Can this be automated?  Even just adding it just to package.json would be an improvement - but then require'ing it on the client side may pull in the whole package, not idea.  Do you do this in other apps at the moment?)