### PR TITLE
Stop config-less init

### DIFF
--- a/main.js
+++ b/main.js
@@ -120,6 +120,12 @@ Tracking.prototype.init = function(config) {
 		config = this._getDeclarativeConfig(config);
 	}
 
+	// If there's no config, there is no point initialising!
+	// http://stackoverflow.com/a/32108184
+	if (Object.keys(config).length === 0 && config.constructor === Object) {
+		return null;
+	}
+
 	settings.set('version', this.version);
 	settings.set('source', this.source);
 	settings.set('api_key', this.api_key);

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -18,6 +18,13 @@ describe('main', function () {
 	after(function () {
 	});
 
+	it('should quit without any config to init with', function() {
+		oTracking.destroy();
+		const tracking = oTracking.init();
+		assert.equal(tracking, null);
+		oTracking.destroy();
+	});
+
 	it('should configure itself from the DOM if no options are present', function() {
 		const confEl = document.createElement('script');
 		confEl.type = 'application/json';


### PR DESCRIPTION
- If o-tracking initialises without config, it is useless
- The auto-init from the dom event keeps racing infront of my manual init with config
- This fix aims to avoid that race and discard the init coming from the dom-event
- Obvs, if the declaritive config is set, then it will still work with `domcontentloaded`