### PR TITLE
Pass secure token under a different attribute

### DIFF
--- a/docs/event-parameters/page-view.md
+++ b/docs/event-parameters/page-view.md
@@ -316,7 +316,7 @@ oTracking.init({
 
 - Key: `user.ft_session`
 - Required: no **yes, if available**
-- Default: *FTSession_s cookie*
+- Default: *FTSession cookie*
 - o-tracking automatic: yes
 - spoor pipeline automatic: yes
 
@@ -326,6 +326,24 @@ The user's current session from membership's session API. If using o-tracking, t
 oTracking.init({
   user: {
     ft_session: ""
+  }
+});
+```
+
+### user_ft_session_s
+
+- Key: `user.ft_session_s`
+- Required: no **yes, if available**
+- Default: *FTSession_s cookie*
+- o-tracking automatic: yes
+- spoor pipeline automatic: yes
+
+The user's current secure session from membership's session API. If using o-tracking, this will be collected for you when available. The pipeline will also make an attempt to collect it from cookies. Otherwise you can set it on init e.g.
+
+```js
+oTracking.init({
+  user: {
+    ft_session_s: ""
   }
 });
 ```

--- a/docs/event-parameters/text-copy.md
+++ b/docs/event-parameters/text-copy.md
@@ -147,7 +147,7 @@ oTracking.init({
 
 - Key: `user.ft_session`
 - Required: no **yes, if available**
-- Default: *FTSession_s cookie*
+- Default: *FTSession cookie*
 - o-tracking automatic: yes
 - spoor pipeline automatic: yes
 
@@ -157,6 +157,24 @@ The user's current session from membership's session API. If using o-tracking, t
 oTracking.init({
   user: {
     ft_session: ""
+  }
+});
+```
+
+### user_ft_session_s
+
+- Key: `user.ft_session_s`
+- Required: no **yes, if available**
+- Default: *FTSession_s cookie*
+- o-tracking automatic: yes
+- spoor pipeline automatic: yes
+
+The user's current secure session from membership's session API. If using o-tracking, this will be collected for you when available. The pipeline will also make an attempt to collect it from cookies. Otherwise you can set it on init e.g.
+
+```js
+oTracking.init({
+  user: {
+    ft_session_s: ""
   }
 });
 ```

--- a/docs/membership_example.md
+++ b/docs/membership_example.md
@@ -35,7 +35,8 @@
                 },
                 user: {
                     passport_id: otracking.utils.getValueFromCookie(/USERID=([0-9]+):/) || otracking.utils.getValueFromCookie(/PID=([0-9]+)\_/),
-                    ft_session: otracking.utils.getValueFromCookie(/FTSession_s=([^;]+)/) || otracking.utils.getValueFromCookie(/FTSession=([^;]+)/)
+                    ft_session: otracking.utils.getValueFromCookie(/FTSession=([^;]+)/),
+                    ft_session_s: otracking.utils.getValueFromCookie(/FTSession_s=([^;]+)/)
                 }
             }
             // oTracking

--- a/src/javascript/core.js
+++ b/src/javascript/core.js
@@ -57,7 +57,8 @@ function track(config, callback) {
 		},
 		user: {
 			passport_id: utils.getValueFromCookie(/USERID=([0-9]+):/) || utils.getValueFromCookie(/PID=([0-9]+)\_/),
-			ft_session: utils.getValueFromCookie(/FTSession_s=([^;]+)/) || utils.getValueFromCookie(/FTSession=([^;]+)/),
+			ft_session: utils.getValueFromCookie(/FTSession=([^;]+)/),
+			ft_session_s: utils.getValueFromCookie(/FTSession_s=([^;]+)/)
 		},
 		device: {
 			spoor_session: session.id,

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -75,7 +75,7 @@ describe('Core', function () {
 			assert.equal(sent_data.context.url, "http://www.ft.com/home/uk");
 
 			// User
-			assert.deepEqual(Object.keys(sent_data.user), ["passport_id","ft_session","user_id"]);
+			assert.deepEqual(Object.keys(sent_data.user), ["passport_id","ft_session","ft_session_s","user_id"]);
 			assert.equal(sent_data.user.user_id, "userID");
 
 			// Device


### PR DESCRIPTION
I'm hoping we can get this out ASAP. The previous change meant that the secure token was still being passed under the `ft_session` attribute. Unfortunately, membership have a different endpoints for validation of secure and non secure tokens `membership/sessions/s/` vs `membership/sessions/`

The previous change meant we were hitting the non secure endpoint with secure tokens and it was failing due to the invalid token type. This had the knock on affect of producing bad data at both Spoor and Ammit. 

I will make the relevant changes to use `ft_session_s` when available so hopefully we can ween ourselves off `ft_session`

@missamynicholson @rowanbeentje @Financial-Times/origami-core 