### PR TITLE
Allow cookie domain to be passed in via config

### DIFF
--- a/main.js
+++ b/main.js
@@ -132,9 +132,10 @@ Tracking.prototype.init = function(config) {
 
 	settings.set('page_sent', false);
 
-	// Set up the user from stored - may later be updated by config
-	user.init();
+	const cookieDomain = config ? config.cookieDomain : false;
 
+	// Set up the user from stored - may later be updated by config
+	user.init(false, cookieDomain);
 	this.updateConfig(config);
 
 	// Session

--- a/src/javascript/core/user.js
+++ b/src/javascript/core/user.js
@@ -24,10 +24,14 @@ const Store = require('./store');
  * @param {String} value The value of a userID to use if one is not stored
  * @return {String} - The user ID if present, or a generated UID if not
  */
-function init(value) {
-	store = new Store(defaultUserConfig.name, defaultUserConfig);
+function init(value, cookieDomain) {
+	if ( cookieDomain ) {
+		defaultUserConfig.domain = cookieDomain;
+	}
 
+	store = new Store(defaultUserConfig.name, defaultUserConfig);
 	let id = store.read();
+
 	if (!id) {
 		id = value;
 	}

--- a/src/javascript/core/user.js
+++ b/src/javascript/core/user.js
@@ -22,6 +22,7 @@ const Store = require('./store');
  * Init
  *
  * @param {String} value The value of a userID to use if one is not stored
+ * @param {String} cookieDomain The domain that should be used to cookie te user
  * @return {String} - The user ID if present, or a generated UID if not
  */
 function init(value, cookieDomain) {


### PR DESCRIPTION
This allows the cookie domain to be passed in via config.

Currently, if we're not on ft.com the cookie defaults to the current domain which is fine in most cases unless we're moving across subdomains. The spoor-id on foo.example.com will be different from bar.example.com which isn't desirable in some cases.