### PR TITLE
IE11 fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ const send = require('./src/javascript/core/send');
  * The version of the tracking module.
  * @type {string}
  */
-const version = '1.2.3';
+const version = '1.4.0';
 /**
  * The source of this event.
  * @type {string}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "o-tracking",
   "description": "This module should be included on your product to make sending tracking requests to the Spoor API easy.",
-  "version": "1.2.3",
+  "version": "1.4.0",
   "main": "main.js",
   "private": true,
   "devDependencies": {

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -7,7 +7,7 @@ const settings = require('./settings');
 const utils = require('../utils');
 const Queue = require('./queue');
 const transports = require('./transports');
-const ie11 = function () { return !!window.MSInputMethodContext && !!document.documentMode };
+const ie11 = function () { return !!window.MSInputMethodContext && !!document.documentMode; };
 /**
  * Default collection server.
  */
@@ -80,9 +80,9 @@ function sendRequest(request, callback) {
 			// If IE11 XHR error, try using image method
 			if (ie11() && transport.name === 'xhr') {
 				let image_method = transports.get('image')();
-				request.system.transport = [request.system.transport,image_method.name].join('-') // Append image label to transport value
+				request.system.transport = [request.system.transport,image_method.name].join('-'); // Append image label to transport value
 				image_method.send(url, JSON.stringify(request));
-				image_method.complete(function () {	
+				image_method.complete(function () {
 					if (callback) {
 						callback();
 					}

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -7,7 +7,7 @@ const settings = require('./settings');
 const utils = require('../utils');
 const Queue = require('./queue');
 const transports = require('./transports');
-const ie11 = function () { return !!window.MSInputMethodContext && !!document.documentMode; };
+const isIe11 = function () { return !!window.MSInputMethodContext && !!document.documentMode; };
 /**
  * Default collection server.
  */
@@ -78,9 +78,10 @@ function sendRequest(request, callback) {
 
 		if (error) {
 			// If IE11 XHR error, try using image method
-			if (ie11() && transport.name === 'xhr') {
+			if (isIe11() && transport.name === 'xhr') {
 				let image_method = transports.get('image')();
-				request.system.transport = [request.system.transport,image_method.name].join('-'); // Append image label to transport value
+				// Append image label to transport value so that we know it tried xhr first
+				request.system.transport = [request.system.transport,image_method.name].join('-');
 				image_method.send(url, JSON.stringify(request));
 				image_method.complete(function () {
 					if (callback) {

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -7,6 +7,7 @@ const settings = require('./settings');
 const utils = require('../utils');
 const Queue = require('./queue');
 const transports = require('./transports');
+const ie11 = function () { return !!window.MSInputMethodContext && !!document.documentMode };
 /**
  * Default collection server.
  */
@@ -49,6 +50,7 @@ function sendRequest(request, callback) {
 		api_key: settings.get('api_key'), // String - API key - Make sure the request is from a valid client (idea nicked from Keen.io) useful if a page gets copied onto a Russian website and creates noise
 		version: settings.get('version'), // Version of the tracking client e.g. '1.2'
 		source: settings.get('source'), // Source of the tracking client e.g. 'o-tracking'
+		transport: transport.name, // The transport method used.
 	});
 
 	request = utils.merge({ system: system }, request);
@@ -75,15 +77,27 @@ function sendRequest(request, callback) {
 		}
 
 		if (error) {
-			// Re-add to the queue if it failed.
-			// Re-apply queueTime here
-			request.queueTime = queueTime;
-			queue.add(request).save();
+			// If IE11 XHR error, try using image method
+			if (ie11() && transport.name === 'xhr') {
+				let image_method = transports.get('image')();
+				request.system.transport = [request.system.transport,image_method.name].join('-') // Append image label to transport value
+				image_method.send(url, JSON.stringify(request));
+				image_method.complete(function () {	
+					if (callback) {
+						callback();
+					}
+				});
+			} else {
+				// Re-add to the queue if it failed.
+				// Re-apply queueTime here
+				request.queueTime = queueTime;
+				queue.add(request).save();
 
-			utils.broadcast('oErrors', 'log', {
-				error: error.message,
-				info: { module: 'o-tracking' }
-			});
+				utils.broadcast('oErrors', 'log', {
+					error: error.message,
+					info: { module: 'o-tracking' }
+				});
+			}
 		} else if (callback) {
 			callback();
 		}
@@ -98,21 +112,6 @@ function sendRequest(request, callback) {
 	// Both developer and noSend flags have to be set to stop the request sending.
 	if (!(settings.get('developer') && settings.get('no_send'))) {
 		transport.send(url, stringifiedData);
-	}
-
-	// Detect IE11
-	const ie11 = !!window.MSInputMethodContext && !!document.documentMode;
-	if (ie11 && request.category === 'page' && request.action === 'view') {
-		// Force use of image method
-		let image_method = transports.get('image')();
-		// Use a clone of the object to avoid mutating original
-		let b2b_data = JSON.parse(stringifiedData);
-		// Change category
-		b2b_data.category = 'ie11';
-		// New ID
-		b2b_data.context.id = utils.guid();
-		// Send it
-		image_method.send(url, JSON.stringify(b2b_data));
 	}
 }
 

--- a/src/javascript/core/transports/image.js
+++ b/src/javascript/core/transports/image.js
@@ -4,6 +4,7 @@ module.exports = function () {
 	const image = new Image(1,1);
 
 	return {
+		name: 'image',
 		send: function (url, data) {
 			image.src = url + (url.indexOf('?') > -1 ? '&' : '?') + 'data=' + utils.encode(data);
 		},

--- a/src/javascript/core/transports/send-beacon.js
+++ b/src/javascript/core/transports/send-beacon.js
@@ -6,6 +6,7 @@ module.exports = function () {
 		rejecter = reject;
 	});
 	return {
+		name: 'send-beacon',
 		send: function (url, data) {
 			if (navigator.sendBeacon(url, data)) {
 				resolver();

--- a/src/javascript/core/transports/send-beacon.js
+++ b/src/javascript/core/transports/send-beacon.js
@@ -6,7 +6,7 @@ module.exports = function () {
 		rejecter = reject;
 	});
 	return {
-		name: 'send-beacon',
+		name: 'sendBeacon',
 		send: function (url, data) {
 			if (navigator.sendBeacon(url, data)) {
 				resolver();

--- a/src/javascript/core/transports/xhr.js
+++ b/src/javascript/core/transports/xhr.js
@@ -2,6 +2,7 @@ module.exports = function () {
 	const xhr = new window.XMLHttpRequest();
 
 	return {
+		name: 'xhr',
 		send: function (url, data) {
 			xhr.open('POST', url, true);
 			xhr.withCredentials = true;

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -249,8 +249,6 @@ describe('Core.Send', function () {
 			server.respondWith([200, { "Content-Type": "plain/text", "Content-Length": 2 }, "OK"]);
 			server.respond();
 
-			console.log(dummyImage);
-
 			// Wait for localStorage
 			setTimeout(() => {
 				// console.log((new Queue('requests')).all());

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -158,7 +158,7 @@ describe('Core.Send', function () {
 			window.Image = sinon.stub().returns(dummyImage);
 			Send.addAndRun(request);
 			setTimeout(() => {
-				assert.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
+				assert.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
 				assert.equal(dummyImage.addEventListener.args[0][0], 'error');
 				assert.equal(dummyImage.addEventListener.args[0][1].length, 1);// it will get passed the error
 				assert.equal(dummyImage.addEventListener.args[1][0], 'load');
@@ -185,7 +185,7 @@ describe('Core.Send', function () {
 			window.Image = sinon.stub().returns(dummyImage);
 			Send.addAndRun(request);
 			setTimeout(() => {
-				assert.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
+				assert.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
 				assert.equal(dummyImage.attachEvent.args[0][0], 'onerror');
 				assert.equal(dummyImage.attachEvent.args[0][1].length, 1);// it will get passed the error
 				assert.equal(dummyImage.attachEvent.args[1][0], 'onload');
@@ -212,6 +212,9 @@ describe('Core.Send', function () {
 			// console.log((new Queue('requests')).storage.storage._type);
 
 			server.respond();
+			// Respond again for Image fallback
+			server.respondWith([500, { "Content-Type": "plain/text", "Content-Length": 5 }, "NOT OK"]);
+			server.respond();
 
 			// Wait for localStorage
 			setTimeout(() => {
@@ -219,6 +222,41 @@ describe('Core.Send', function () {
 
 				assert.ok((new Queue('requests')).last().queueTime);
 				navigator.sendBeacon = b;
+				server.restore();
+				done();
+			}, 100);
+		});
+
+		it('should try image transport in IE11 if XHR fails.', function (done) {
+			const server = sinon.fakeServer.create(); // Catch AJAX requests
+	
+			// Fake IE11
+			window.MSInputMethodContext = true;
+			document.documentMode = true;
+
+			(new Queue('requests')).replace([]);
+			Send.init();
+			const dummyImage = {
+				attachEvent: sinon.stub()
+			};
+			const i = window.Image;
+			window.Image = sinon.stub().returns(dummyImage);
+	
+			server.respondWith([500, { "Content-Type": "plain/text", "Content-Length": 5 }, "NOT OK"]);
+			Send.addAndRun(request);
+			server.respond();
+			// Respond OK for the image
+			server.respondWith([200, { "Content-Type": "plain/text", "Content-Length": 2 }, "OK"]);
+			server.respond();
+			
+			console.log(dummyImage);
+
+			// Wait for localStorage
+			setTimeout(() => {
+				// console.log((new Queue('requests')).all());
+				assert.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22xhr-image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
+	
+				window.Image = i;
 				server.restore();
 				done();
 			}, 100);

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -229,7 +229,7 @@ describe('Core.Send', function () {
 
 		it('should try image transport in IE11 if XHR fails.', function (done) {
 			const server = sinon.fakeServer.create(); // Catch AJAX requests
-	
+
 			// Fake IE11
 			window.MSInputMethodContext = true;
 			document.documentMode = true;
@@ -241,21 +241,21 @@ describe('Core.Send', function () {
 			};
 			const i = window.Image;
 			window.Image = sinon.stub().returns(dummyImage);
-	
+
 			server.respondWith([500, { "Content-Type": "plain/text", "Content-Length": 5 }, "NOT OK"]);
 			Send.addAndRun(request);
 			server.respond();
 			// Respond OK for the image
 			server.respondWith([200, { "Content-Type": "plain/text", "Content-Length": 2 }, "OK"]);
 			server.respond();
-			
+
 			console.log(dummyImage);
 
 			// Wait for localStorage
 			setTimeout(() => {
 				// console.log((new Queue('requests')).all());
 				assert.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22xhr-image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
-	
+
 				window.Image = i;
 				server.restore();
 				done();


### PR DESCRIPTION
With this update the aim is to capture some events we've realised we're missing from IE11.

The changes mean o-tracking will fall back to image requests for IE11 when the AJAX version fails.
I have also added the transport method used to all requests so we can get stats on this.

This chart shows we are missing about 3% of events by not using Image tags (it's a subtraction of the IE11 test events from normal events, the pink area shows additional events we haven't been capturing)
![screen shot 2018-09-05 at 10 31 38](https://user-images.githubusercontent.com/1125535/45085092-bf700380-b0f7-11e8-9004-7404432a76e5.png)

But, this chart shows Image tags by themselves are not reliable enough, so we need to use the combination of AJAX and Image to try and get the most reliable result. (The image line is generally about 3%-5% below the AJAX line.)
![screen shot 2018-09-05 at 10 31 45](https://user-images.githubusercontent.com/1125535/45085135-df9fc280-b0f7-11e8-9079-334607c866cb.png)