### PR TITLE
Image uses image

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ const send = require('./src/javascript/core/send');
  * The version of the tracking module.
  * @type {string}
  */
-const version = '1.4.0';
+const version = '1.4.1';
 /**
  * The source of this event.
  * @type {string}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "o-tracking",
   "description": "This module should be included on your product to make sending tracking requests to the Spoor API easy.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "main.js",
   "private": true,
   "devDependencies": {

--- a/src/javascript/core/transports/image.js
+++ b/src/javascript/core/transports/image.js
@@ -6,6 +6,7 @@ module.exports = function () {
 	return {
 		name: 'image',
 		send: function (url, data) {
+			url = url.replace('https://spoor-api.ft.com/ingest', 'https://spoor-api.ft.com/px.gif');
 			image.src = url + (url.indexOf('?') > -1 ? '&' : '?') + 'data=' + utils.encode(data);
 		},
 		complete: function (callback) {


### PR DESCRIPTION
This is a test to see if IE is happier with an image response for Image transport rather than the normal html response from /ingest

See example traffic from a customer
![screen shot 2018-11-05 at 12 33 51](https://user-images.githubusercontent.com/1125535/47998404-1d6c9780-e0f7-11e8-88b6-aaa0f6ada4a5.png)
It's recognising the AJAX method won't work and falling back to Images, which is great, but then also see the images don't make it through and are aborted.