### PR TITLE
no!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,33 +2,35 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:10-browsers
     steps:
       - checkout
-      - run:
-          name: Ensure package.json exists for caching
-          command: if [[ ! -f package.json ]]; then echo "{}" > package.json; fi
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}-{{ checksum "bower.json" }}
-      - run:
-          name: Install dependencies
-          command: npx origami-build-tools@^7 install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}-{{ checksum "bower.json" }}
-          paths:
-            - node_modules
-            - bower_components
-      - run:
-          name: Build accessibility testing demo
-          command: npx origami-build-tools@^7 demo --demo-filter pa11y --suppress-errors
-      - run:
-          name: Run linters
-          command: npx origami-build-tools@^7 verify
-      - run:
-          name: Run tests
-          command: npx origami-build-tools@^7 test
+      - run: npm config set prefix "$HOME/.local"
+      - run: npm i -g origami-build-tools@^7
+      - run: $HOME/.local/bin/obt install
+      - run: $HOME/.local/bin/obt demo --demo-filter pa11y --suppress-errors
+      - run: $HOME/.local/bin/obt verify
+      - run: $HOME/.local/bin/obt test
+      - run: git clean -fxd
+      - run: npx occ 0.0.0
+      - run: $HOME/.local/bin/obt install --ignore-bower
+      - run: $HOME/.local/bin/obt test --ignore-bower
+  publish_to_npm:
+    docker:
+      - image: circleci/node:10
+    steps:
+      - checkout
+      - run: npx occ ${CIRCLE_TAG##v}
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > $HOME/.npmrc
+      - run: npm publish --access public 
 workflows:
   version: 2
   test:
     jobs:
       - test
+      - publish_to_npm:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
anything that is not origami team maintained, but is published to npm by the origami team becomes implicitly maintained because if the npm version fails it will be origami that is maintaining it.