### PR TITLE
Add impression(component:view) tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ function oTrackinginit() {
     oTracking.page({...config...});
     // Clicks.
     oTracking.click.init(category);
+    // Components/Elements views.
+    oTracking.view.init({...opts...});
 }
 ```
 
@@ -79,6 +81,8 @@ if (cutsTheMustard) {
     oTracking.page({...config...});
     // Clicks
     oTracking.click.init(category);
+    // Components/Elements views.
+    oTracking.view.init({...opts...});
 }
 ```
 
@@ -188,6 +192,25 @@ o-tracking will
 * Automatically pickup ftsession from cookies for you.
 * Page events automatically pick up the url and the referrer.
 * Click events [initalised as above](#usage), will populate a `domPathTokens` property. If the clicked element has the `data-trackable` attribute, sibling elements will also be included within `domPathTokens`.
+* View events are fired for elements with the `data-o-tracking-view` attribute by default, unless `o-tracking`'s `selector` option is configured. Like click events, view events populate a `domPathTokens` property. To collect data for events, set the `category` option, or provide a callback[`getContextData`]  
+_Note:_ This feature requires `window.IntersectionObserver` in order to track the events  
+_Note:_ `getContextData` should be a function which returns `{Object}`. It accepts the viewed element as an argument  
+	```js
+	const opts = {
+		category: 'audio', // default: 'component'
+		selector: '.o-teaser__audio', // default: '[data-o-tracking-view]'
+		getContextData: (el) => {  // default: null
+			return {
+				contentId: el.getAttribute('data-id'),
+				type: 'audio',
+				subtype: 'podcast',
+			 	component: 'teaser'
+			};
+		}
+	}
+
+	oTracking.view.init(opts);
+	```
 
 Events are decorated with config values you pass in via `init()` or `updateConfig()` if they are part of `context`, `user`, or `device` objects. Values passed in as `context` to individual events will override context values from init.
 

--- a/main.js
+++ b/main.js
@@ -84,6 +84,12 @@ Tracking.prototype.event = require('./src/javascript/events/custom');
 Tracking.prototype.page = require('./src/javascript/events/page-view');
 
 /**
+* To initalise view events for components/elements.
+* @see {@link view#init}
+*/
+Tracking.prototype.view = require('./src/javascript/events/component-view');
+
+/**
  * To initalise click events.
  * @see {@link click#init}
  */

--- a/origami.json
+++ b/origami.json
@@ -11,7 +11,9 @@
 	"supportStatus": "active",
 	"browserFeatures": {
 		"required": [
-			"CustomEvent"
+			"CustomEvent",
+			"IntersectionObserver",
+			"IntersectionObserverEntry"
 		],
 		"optional": [
 			"Promise",

--- a/src/javascript/events/component-view.js
+++ b/src/javascript/events/component-view.js
@@ -1,0 +1,87 @@
+/*global module, require */
+'use strict'; // eslint-disable-line strict
+
+const Core = require('../core');
+const getTrace = require('../../libs/get-trace');
+const utils = require('../utils');
+
+const TRACKING_ATTRIBUTES = [
+	'contentId',
+	'type',
+	'subtype',
+	'component',
+];
+
+const decorateEventData = (eventData, viewedEl, opts) => {
+
+	const { trace, customContext } = getTrace(viewedEl);
+	let context;
+
+	if (opts.getContextData) {
+		if (typeof opts.getContextData !== 'function') {
+			throw new Error('opts.getContextData is not a function');
+		}
+
+		const dataBeforeWhitelist = opts.getContextData(viewedEl);
+
+		if (typeof dataBeforeWhitelist !== 'object') {
+			throw new Error('opts.getContextData function should return {Object}');
+		}
+
+		context = utils.whitelistProps(dataBeforeWhitelist, TRACKING_ATTRIBUTES);
+	} else {
+		context = {};
+	}
+
+	context.domPathTokens = trace;
+	context.url = window.document.location.href || null;
+
+	utils.assignIfUndefined(customContext, context);
+
+	eventData.context = context;
+};
+
+/**
+ * Listen for view events.
+ *
+ * @alias view#init
+ * @param {Object} opts - To set custom category[String], selector[String], getContextData[Function]
+ * @return {undefined}
+ */
+const init = (opts = {}) => {
+	if(!window.IntersectionObserver) {
+		return;
+	}
+
+	const selector = opts.selector || '[data-o-tracking-view]';
+	const elementsToTrack = [...document.querySelectorAll(selector)];
+
+	if (!elementsToTrack.length) {
+		console.warn('o-tracking: Unable to track element view events as "window.IntersectionObserver" is not supported.');
+		return;
+	}
+
+	function onChange (changes) {
+		changes.forEach(change => {
+			if(change.isIntersecting || change.intersectionRatio > 0) {
+				const eventData = {
+					action: 'view',
+					category: opts.category || 'component'
+				};
+				const viewedEl = change.target;
+
+				decorateEventData(eventData, viewedEl, opts);
+				Core.track(eventData);
+				this.unobserve(viewedEl);
+			}
+		});
+	}
+
+	const observer = new IntersectionObserver(onChange, { threshold: [ 1.0 ] });
+
+	elementsToTrack.forEach(el => observer.observe(el));
+};
+
+module.exports = {
+	init: init
+};

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -214,6 +214,47 @@ function getValueFromJsVariable(str) {
 	return test !== '' ? test : null;
 }
 
+/**
+ * Trim strings
+ * @param {String} str - The string to trim.
+ * @return {String} The trimmed string.
+ */
+function sanitise (str) {
+	return typeof str === 'string' ? str.trim() : str;
+}
+
+/**
+ * Assign the subject value if the target properties are undefined
+ * @param {Object} subject - assign the value
+ * @param {Object} target - be assigned the value
+ * @return
+ */
+function assignIfUndefined (subject, target) {
+	for (const prop in subject) {
+		if (!target[prop]) {
+			target[prop] = subject[prop];
+		} else {
+			console.warn(`You can't set a custom property called ${prop}`);
+		}
+	}
+}
+
+/**
+ * Whitelist props
+ * @param {Object} props - An object whose props need to be whitelisted
+ * @param {Array} list - A list for whitelisting
+ * @return
+ */
+function whitelistProps (props, list) {
+	return list.reduce(
+		(acc, propName) => Object.assign(
+			{},
+			acc,
+			props[propName] ? { [propName]: props[propName] } : undefined
+		),
+		{}
+	);
+}
 
 /**
  * Utilities.
@@ -233,5 +274,8 @@ module.exports = {
 	triggerPage: triggerPage,
 	getValueFromCookie: getValueFromCookie,
 	getValueFromUrl: getValueFromUrl,
-	getValueFromJsVariable: getValueFromJsVariable
+	getValueFromJsVariable: getValueFromJsVariable,
+	sanitise: sanitise,
+	assignIfUndefined: assignIfUndefined,
+	whitelistProps: whitelistProps,
 };

--- a/src/libs/get-trace.js
+++ b/src/libs/get-trace.js
@@ -1,0 +1,110 @@
+// Trace the element and all of its parents, collecting properties as we go
+
+const utils = require('../javascript/utils');
+
+const elementPropertiesToCollect = [
+	"nodeName",
+	"className",
+	"id",
+	"href",
+	"text",
+	"role",
+];
+
+// For a given container element, get the number of elements that match the
+// original element (siblings); and the index of the original element (position).
+const getSiblingsAndPosition = (el, originalEl, selector) => {
+	const siblings = Array.from(el.querySelectorAll(selector));
+	const position = siblings.findIndex(item => item === originalEl);
+	if(position === -1) {return;}
+	return {
+		siblings: siblings.length,
+		position,
+	};
+};
+
+// Get all (sanitised) properties of a given element.
+const getAllElementProperties = el => {
+	return elementPropertiesToCollect.reduce((returnObject, property) => {
+		if (el[property]) {
+			returnObject[property] = utils.sanitise(el[property]);
+		}
+		else if (el.getAttribute(property)) {
+			returnObject[property] = utils.sanitise(el.getAttribute(property));
+		}
+		else if (el.hasAttribute(property)) {
+			returnObject[property] = el.hasAttribute(property);
+		}
+		return returnObject;
+	}, {});
+};
+
+// Get some properties of a given element.
+const getDomPathProps = (attrs, props) => {
+
+	// Collect any attribute that matches given strings.
+	attrs
+		.filter(attribute => attribute.name.match(/^data-trackable|^data-o-|^aria-/i))
+		.forEach(attribute => {
+			props[attribute.name] = attribute.value;
+		});
+
+	return props;
+};
+
+// Get only the custom data-trackable-context-? properties of a given element
+const getContextProps = (attrs, props, isOriginalEl) => {
+
+	const customProps = {};
+
+	// for the original element collect properties like className, nodeName
+	if (isOriginalEl) {
+		elementPropertiesToCollect.forEach(name => {
+			if (typeof props[name] !== 'undefined' && name !== 'id') {
+				customProps[name] = props[name];
+			}
+		});
+	}
+
+	// Collect any attribute that matches given strings.
+	attrs
+		.filter(attribute => attribute.name.match(/^data-trackable-context-/i))
+		.forEach(attribute => {
+			customProps[attribute.name.replace('data-trackable-context-', '')] = attribute.value;
+		});
+
+	return customProps;
+};
+
+function getTrace (el) {
+	const rootEl = document;
+	const originalEl = el;
+	const selector = originalEl.getAttribute('data-trackable') ? `[data-trackable="${originalEl.getAttribute('data-trackable')}"]` : originalEl.nodeName;
+	const trace = [];
+	const customContext = {};
+	while (el && el !== rootEl) {
+		const props = getAllElementProperties(el);
+		const attrs = Array.from(el.attributes);
+		let domPathProps = getDomPathProps(attrs, props);
+
+		// If the element happens to have a data-trackable attribute, get the siblings
+		// and position of the element (relative to the current element).
+		if (domPathProps["data-trackable"]) {
+			domPathProps = Object.assign(
+				domPathProps,
+				getSiblingsAndPosition(el, originalEl, selector)
+			);
+		}
+
+		trace.push(domPathProps);
+
+		const contextProps = getContextProps(attrs, props, el === originalEl);
+
+		utils.assignIfUndefined(contextProps, customContext);
+
+		el = el.parentNode;
+	}
+	return { trace, customContext };
+}
+
+module.exports = getTrace;

--- a/test/events/component-view.test.js
+++ b/test/events/component-view.test.js
@@ -1,0 +1,226 @@
+/*global require, describe, it, before, after, sinon, document */
+require('../setup');
+const assert = require('assert');
+const settings = require('../../src/javascript/core/settings');
+const send = require('../../src/javascript/core/send');
+const core = require('../../src/javascript/core');
+const session = require('../../src/javascript/core/session');
+const componentView = require('../../src/javascript/events/component-view');
+
+const config = {
+	context: {
+		product: 'desktop'
+	},
+	user: {
+		user_id: '123456'
+	},
+};
+
+let targetComponent;
+let errorThrown;
+
+function createTargetComponent (attributes, text) {
+	targetComponent = document.createElement('div');
+	attributes.forEach(attr => targetComponent.setAttribute(attr.key, attr.value));
+	targetComponent.innerHTML = text;
+	document.body.appendChild(targetComponent);
+}
+
+function viewed (target) {
+	const event = new Event('intersect');
+	target.dispatchEvent(event);
+}
+
+function setMockIntersectionObserver (observeSpy, unobserveSpy) {
+	function mockIntersectionObserver(callback, options) {
+		this.callback = callback;
+		this.options = options;
+	}
+
+	mockIntersectionObserver.prototype.observe = function (target) {
+		target.addEventListener('intersect', () => {
+			try {
+				this.callback([{ isIntersecting: true, target }]);
+			} catch (e) {
+				errorThrown = e;
+			}
+		});
+		observeSpy(target);
+	};
+
+	mockIntersectionObserver.prototype.unobserve = function (target) {
+		unobserveSpy(target);
+	};
+
+	window.IntersectionObserver = mockIntersectionObserver;
+}
+
+
+describe('component:view', () => {
+
+	const observeSpy = sinon.spy();
+	const unobserveSpy = sinon.spy();
+
+	beforeEach(() => {
+		session.init();
+		send.init();
+		settings.set('config', config);
+		setMockIntersectionObserver(observeSpy, unobserveSpy);
+		sinon.spy(core, 'track');
+	});
+
+	afterEach(() => {
+		observeSpy.resetHistory();
+		unobserveSpy.resetHistory();
+		document.body.removeChild(targetComponent);
+		targetComponent = undefined;
+		errorThrown = undefined;
+		core.track.restore();
+	});
+
+	context('with default props', () => {
+		beforeEach(() => {
+			const attributes = [{ key: 'data-o-tracking-view', value: true }];
+			const text = 'component:view target for default props';
+
+			createTargetComponent(attributes, text);
+			componentView.init();
+			viewed(targetComponent);
+		});
+
+		it('should track an event for a component view ', () => {
+			assert.equal(errorThrown, undefined);
+			assert.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
+			assert.equal(unobserveSpy.calledOnce, true, 'IntersectionObserver unobserved target');
+			assert.equal(core.track.calledOnce, true, 'view event tracked');
+		});
+
+		it('should track with correct detail', () => {
+			assert.equal(core.track.getCall(0).args[0].category, 'component');
+			assert.equal(core.track.getCall(0).args[0].action, 'view');
+			assert.ok(core.track.getCall(0).args[0].context.domPathTokens, true);
+		});
+	});
+
+	context('with custom props', () => {
+		const category = 'custom';
+		const id = '1234';
+		const type = 'audio';
+		const targetAttribute = 'data-custom-element';
+		const idAttribute = 'data-id';
+		const attributes = [
+			{ key: targetAttribute, value: true },
+			{ key: idAttribute, value: id },
+		];
+		const text = 'component:view target for custom props';
+
+		beforeEach(() => {
+			createTargetComponent(attributes, text);
+		});
+
+		describe('given correct', () => {
+			beforeEach(() => {
+				const opts = {
+					category,
+					selector: `[${targetAttribute}]`,
+					getContextData: (el) => {
+						return { contentId: el.getAttribute(idAttribute), type };
+					},
+				};
+
+				componentView.init(opts);
+				viewed(targetComponent);
+			});
+
+			it('should track an event for a component view', () => {
+				assert.equal(errorThrown, undefined);
+				assert.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
+				assert.equal(unobserveSpy.calledOnce, true, 'IntersectionObserver unobserved target');
+				assert.equal(core.track.calledOnce, true, 'view event tracked');
+			});
+
+			it('should track with correct detail', () => {
+				const trackedDetail = core.track.getCall(0).args[0];
+
+				assert.equal(trackedDetail.category, category);
+				assert.equal(trackedDetail.action, 'view');
+				assert.ok(trackedDetail.context.domPathTokens, true);
+				assert.equal(trackedDetail.context.contentId, id);
+				assert.equal(trackedDetail.context.type, type);
+			});
+		});
+
+		describe('given wrong', () => {
+			context('getContextData is not a function', () => {
+				beforeEach(() => {
+					const opts = {
+						selector: `[${targetAttribute}]`,
+						getContextData: {},
+					};
+
+					componentView.init(opts);
+					viewed(targetComponent);
+				});
+
+				it('should throw an error', () => {
+					assert.equal(errorThrown.message, 'opts.getContextData is not a function');
+					assert.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
+					assert.equal(unobserveSpy.calledOnce, false, 'IntersectionObserver unobserved target');
+					assert.equal(core.track.calledOnce, false, 'view event tracked');
+				});
+			});
+
+			context('getContextData returns non-Object', () => {
+				beforeEach(() => {
+					const opts = {
+						selector: `[${targetAttribute}]`,
+						getContextData: (el) => `${el}`,
+					};
+
+					componentView.init(opts);
+					viewed(targetComponent);
+				});
+
+				it('should throw an error', () => {
+					assert.equal(errorThrown.message, 'opts.getContextData function should return {Object}');
+					assert.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
+					assert.equal(unobserveSpy.calledOnce, false, 'IntersectionObserver unobserved target');
+					assert.equal(core.track.calledOnce, false, 'view event tracked');
+				});
+			});
+
+			context('getContextData returns an Object includes non-whitelist props', () => {
+				beforeEach(() => {
+					const opts = {
+						selector: `[${targetAttribute}]`,
+						getContextData: (el) => {
+							return {
+								contentId: el.getAttribute(idAttribute),
+								name: 'name',
+							};
+						},
+					};
+
+					componentView.init(opts);
+					viewed(targetComponent);
+				});
+
+				it('should not throw an error', () => {
+					assert.equal(errorThrown, undefined);
+					assert.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
+					assert.equal(unobserveSpy.calledOnce, true, 'IntersectionObserver unobserved target');
+					assert.equal(core.track.calledOnce, true, 'view event tracked');
+				});
+
+				it('should not have non-whitelist props in event detail', () => {
+					const trackedDetail = core.track.getCall(0).args[0];
+
+					assert.equal(trackedDetail.context.contentId, id);
+					assert.equal(trackedDetail.context.name, undefined);
+				});
+			});
+
+		});
+	});
+
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -70,4 +70,47 @@ describe('Utils', function () {
 		assert.ok(Utils.getValueFromJsVariable);
 	});
 
+	it('should provide sanitise functionality', function () {
+		[
+			{ param: '   with space  ', result: 'with space' },
+			{ param: 'noSpace', result: 'noSpace' }
+	 	].forEach(function (test) {
+			assert.equal(Utils.sanitise(test.param), test.result);
+		});
+	});
+
+	it('should provide assignIfUndefined functionality', function () {
+		[
+			{
+				subject: { a: 'aa', b: 'b', c: 'c' },
+				target: { a: 'a', b: undefined },
+				result: { a: 'a', b: 'b', c: 'c' }
+			}
+		].forEach(function (test) {
+			Utils.assignIfUndefined(test.subject, test.target);
+			assert.deepEqual(test.target, test.result);
+		});
+	});
+
+	it('should provide whitelistProps functionality', function () {
+		const whitelist = [ 'contentId', 'type' ];
+
+		[
+			{
+				target: { contentId: 1234, type: 'audio' },
+				result: { contentId: 1234, type: 'audio' }
+			},
+			{
+				target: { contentId: 1234, name: 'name' },
+				result: { contentId: 1234 }
+			},
+			{
+				target: { contentId: undefined },
+				result: {}
+			}
+		].forEach(function (test) {
+			assert.deepEqual(Utils.whitelistProps(test.target, whitelist), test.result);
+		});
+	});
+
 });


### PR DESCRIPTION
Component view events will be fired with elements set `data-o-tracking-view` attribute or elements collected by a custom selector in `opts`. They will populate a `domPathTokens` as well as Click events. You could pass a custom category, and also a callback[`getContextData`] to collect data for events.  

:warning: This feature requires `window.IntersectionObserver` in order to track the events  
:warning: `getContextData` should be a function which returns `{Object}`

```js
const opts = {
	category: 'audio', // default: 'component'
	selector: '.o-teaser__audio', // default: '[data-o-tracking-view]'
	getContextData: () => {  // default: null
		return {
			contentId: '1234',
			type: 'audio',
			subtype: 'podcast',
		 	component: 'teaser'
		};
	}
}

oTracking.view.init(opts);
```