### PR TITLE
component:view tracking: Modify contentId => componentContentId

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ _Note:_ `getContextData` should be a function which returns `{Object}`. It accep
 		selector: '.o-teaser__audio', // default: '[data-o-tracking-view]'
 		getContextData: (el) => {  // default: null
 			return {
-				contentId: el.getAttribute('data-id'),
+				componentContentId: el.getAttribute('data-id'),
 				type: 'audio',
 				subtype: 'podcast',
 			 	component: 'teaser'

--- a/src/javascript/events/component-view.js
+++ b/src/javascript/events/component-view.js
@@ -6,7 +6,7 @@ const getTrace = require('../../libs/get-trace');
 const utils = require('../utils');
 
 const TRACKING_ATTRIBUTES = [
-	'contentId',
+	'componentContentId',
 	'type',
 	'subtype',
 	'component',

--- a/test/events/component-view.test.js
+++ b/test/events/component-view.test.js
@@ -124,7 +124,7 @@ describe('component:view', () => {
 					category,
 					selector: `[${targetAttribute}]`,
 					getContextData: (el) => {
-						return { contentId: el.getAttribute(idAttribute), type };
+						return { componentContentId: el.getAttribute(idAttribute), type };
 					},
 				};
 
@@ -145,7 +145,7 @@ describe('component:view', () => {
 				assert.equal(trackedDetail.category, category);
 				assert.equal(trackedDetail.action, 'view');
 				assert.ok(trackedDetail.context.domPathTokens, true);
-				assert.equal(trackedDetail.context.contentId, id);
+				assert.equal(trackedDetail.context.componentContentId, id);
 				assert.equal(trackedDetail.context.type, type);
 			});
 		});
@@ -195,7 +195,7 @@ describe('component:view', () => {
 						selector: `[${targetAttribute}]`,
 						getContextData: (el) => {
 							return {
-								contentId: el.getAttribute(idAttribute),
+								componentContentId: el.getAttribute(idAttribute),
 								name: 'name',
 							};
 						},
@@ -215,7 +215,7 @@ describe('component:view', () => {
 				it('should not have non-whitelist props in event detail', () => {
 					const trackedDetail = core.track.getCall(0).args[0];
 
-					assert.equal(trackedDetail.context.contentId, id);
+					assert.equal(trackedDetail.context.componentContentId, id);
 					assert.equal(trackedDetail.context.name, undefined);
 				});
 			});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -93,19 +93,19 @@ describe('Utils', function () {
 	});
 
 	it('should provide whitelistProps functionality', function () {
-		const whitelist = [ 'contentId', 'type' ];
+		const whitelist = [ 'componentContentId', 'type' ];
 
 		[
 			{
-				target: { contentId: 1234, type: 'audio' },
-				result: { contentId: 1234, type: 'audio' }
+				target: { componentContentId: 1234, type: 'audio' },
+				result: { componentContentId: 1234, type: 'audio' }
 			},
 			{
-				target: { contentId: 1234, name: 'name' },
-				result: { contentId: 1234 }
+				target: { componentContentId: 1234, name: 'name' },
+				result: { componentContentId: 1234 }
 			},
 			{
-				target: { contentId: undefined },
+				target: { componentContentId: undefined },
 				result: {}
 			}
 		].forEach(function (test) {


### PR DESCRIPTION
Impressions on article pages having both **contentID**(the component's content id) and **rootContentID**(the article's content id) is potentially confusing. We rename **contentID** to **componentContentID** so it is very clear what that applies to.