### PR TITLE
Expose getRootID() on the oTracking object

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ const settings = require('./src/javascript/core/settings');
 const user = require('./src/javascript/core/user');
 const session = require('./src/javascript/core/session');
 const send = require('./src/javascript/core/send');
+const core = require('./src/javascript/core');
 
 /**
  * The version of the tracking module.
@@ -106,6 +107,12 @@ Tracking.prototype.link = { init: _ => Tracking.prototype.click.init('link') }; 
  * @see {@link utils}
  */
 Tracking.prototype.utils = require('./src/javascript/utils');
+
+/**
+ * Get the rootID.
+ * @see {@link utils}
+ */
+Tracking.prototype.getRootID = core.getRootID;
 
 /**
  * Initialises the Tracking object.

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -261,4 +261,8 @@ describe('main', function () {
 		assert.equal(data.context.marketing.banner_closed, true);
 		assert.equal(data.context.marketing.segid, '4321');
 	});
+
+	it('should have getRoodID() as an accessible method', () => {
+		assert.equal(typeof oTracking.getRootID, 'function');
+	});
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -262,7 +262,7 @@ describe('main', function () {
 		assert.equal(data.context.marketing.segid, '4321');
 	});
 
-	it('should have getRoodID() as an accessible method', () => {
+	it('should have getRootId() as an accessible method', () => {
 		assert.equal(typeof oTracking.getRootID, 'function');
 	});
 });


### PR DESCRIPTION
We require Markets Data to add a rootID to the page and pass it into oAds. They don't use n-ui but they do use oTracking, from the build service. This PR enables them to get a rootId for the markets data page.