### PR TITLE
Remove version from `package.json`. Update version in `main.js`

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ const core = require('./src/javascript/core');
  * The version of the tracking module.
  * @type {string}
  */
-const version = '1.4.2';
+const version = '2.0.0';
 /**
  * The source of this event.
  * @type {string}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "o-tracking",
 	"description": "This module should be included on your product to make sending tracking requests to the Spoor API easy.",
-	"version": "1.4.2",
 	"main": "main.js",
 	"private": true,
 	"devDependencies": {


### PR DESCRIPTION
Thie commit removes the version number from `package.json`
to align with the Origami spec (it's currently outdated anyway).

The version number is also set in `main.js` is incorrect. This commit
updates it for the new major. It's likely to fall out of date again.
We should consider removing it in a future version of o-tracking but
first need to understand if/how it's used.

https://github.com/Financial-Times/o-tracking/issues/195