### PR TITLE
Remove the `main` field from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
 	"name": "o-tracking",
 	"description": "This module should be included on your product to make sending tracking requests to the Spoor API easy.",
 	"version": "1.4.2",
-	"main": "main.js",
 	"private": true,
 	"devDependencies": {
 		"origami-build-tools": "^7.2.0",


### PR DESCRIPTION
This is not allowed by the spec.
https://origami.ft.com/spec/v1/components/#npm