### PR TITLE
Export the o-tracking init function.

### DIFF
--- a/main.js
+++ b/main.js
@@ -263,6 +263,7 @@ Tracking.prototype._getDeclarativeConfig = function(options) {
 };
 
 const tracking = new Tracking();
+const init = tracking.init.bind(tracking);
 
 function initialise() {
 	tracking.init();
@@ -280,4 +281,7 @@ document.addEventListener('o.DOMContentLoaded', initialise);
  * @type {Tracking}
  */
 export default tracking;
-export { tracking };
+export {
+	tracking,
+	init
+};


### PR DESCRIPTION
Many users are including o-tracking without a semver range:
`https://build.origami.ft.com/bundles/js?modules=o-tracking`

This makes o-tracking v2 compatible with v1 for their usecase via
the build service.