### PR TITLE
Export some o-tracking functions.

### DIFF
--- a/main.js
+++ b/main.js
@@ -264,6 +264,10 @@ Tracking.prototype._getDeclarativeConfig = function(options) {
 
 const tracking = new Tracking();
 const init = tracking.init.bind(tracking);
+const link = tracking.link.bind(tracking);
+const boundPage = tracking.page.bind(tracking);
+const boundEvent = tracking.event.bind(tracking);
+const updateConfig = tracking.updateConfig.bind(tracking);
 
 function initialise() {
 	tracking.init();
@@ -283,5 +287,9 @@ document.addEventListener('o.DOMContentLoaded', initialise);
 export default tracking;
 export {
 	tracking,
-	init
+	init,
+	link,
+	boundPage as page,
+	boundEvent as event,
+	updateConfig
 };


### PR DESCRIPTION
Many users are including o-tracking without a semver range:
`https://build.origami.ft.com/bundles/js?modules=o-tracking`

This makes o-tracking v2 compatible with v1 for their usecase via
the build service.