### PR TITLE
Export an object containing init from events/component-view

### DIFF
--- a/src/javascript/events/component-view.js
+++ b/src/javascript/events/component-view.js
@@ -1,4 +1,3 @@
-
 import Core from '../core';
 import getTrace from '../../libs/get-trace';
 import utils from '../utils';
@@ -80,6 +79,6 @@ const init = (opts = {}) => {
 	elementsToTrack.forEach(el => observer.observe(el));
 };
 
-export default init;
+export default { init };
 export { init };
 

--- a/test/events/component-view.test.js
+++ b/test/events/component-view.test.js
@@ -84,7 +84,7 @@ describe('component:view', () => {
 			const text = 'component:view target for default props';
 
 			createTargetComponent(attributes, text);
-			componentView();
+			componentView.init();
 			viewed(targetComponent);
 		});
 
@@ -128,7 +128,7 @@ describe('component:view', () => {
 					},
 				};
 
-				componentView(opts);
+				componentView.init(opts);
 				viewed(targetComponent);
 			});
 
@@ -158,7 +158,7 @@ describe('component:view', () => {
 						getContextData: {},
 					};
 
-					componentView(opts);
+					componentView.init(opts);
 					viewed(targetComponent);
 				});
 
@@ -177,7 +177,7 @@ describe('component:view', () => {
 						getContextData: (el) => `${el}`,
 					};
 
-					componentView(opts);
+					componentView.init(opts);
 					viewed(targetComponent);
 				});
 
@@ -201,7 +201,7 @@ describe('component:view', () => {
 						},
 					};
 
-					componentView(opts);
+					componentView.init(opts);
 					viewed(targetComponent);
 				});
 


### PR DESCRIPTION
because that's what used to be exported:
https://github.com/Financial-Times/o-tracking/blob/v1.7.3/src/javascript/events/component-view.js#L85-L87

(the init function was never the main export)