### PR TITLE
Fix libs/get-trace export

### DIFF
--- a/src/libs/get-trace.js
+++ b/src/libs/get-trace.js
@@ -107,4 +107,4 @@ function getTrace (el) {
 	return { trace, customContext };
 }
 
-module.exports = getTrace;
+export default getTrace;


### PR DESCRIPTION
`o-tracking` uses import/export everywhere except this one in `libs/get-trace.js`.

I found this when I tried to build `n-messaging-client` using Webpack 4.
Error I got when I tried to load the bundled JS in Chrome:

```
get-trace.js:112 Uncaught TypeError: Cannot assign to read only property 'exports' of object '#<Object>'
    at Module.eval (get-trace.js:112)
    at eval (get-trace.js:114)
    at Module../bower_components/o-tracking/src/libs/get-trace.js (main.js:525)
    at __webpack_require__ (main.js:20)
    at eval (click.js:8)
    at Module../bower_components/o-tracking/src/javascript/events/click.js (main.js:453)
    at __webpack_require__ (main.js:20)
    at eval (main.js:14)
    at Module../bower_components/o-tracking/main.js (main.js:309)
    at __webpack_require__ (main.js:20)
```

and Webpack warned:

```
WARNING in ./bower_components/o-tracking/src/javascript/events/click.js 58:33-41
"export 'default' (imported as 'getTrace') was not found in '../../libs/get-trace'
 @ ./bower_components/o-tracking/main.js
 @ ./demos/src/demo.js

WARNING in ./bower_components/o-tracking/src/javascript/events/component-view.js 14:34-42
"export 'default' (imported as 'getTrace') was not found in '../../libs/get-trace'
 @ ./bower_components/o-tracking/main.js
 @ ./demos/src/demo.js
 ```

`webpack.config.js` I used:

```
module.exports = {
  mode: 'development',
  resolve: {
    modules: [__dirname + '/../bower_components', __dirname + '/../node_modules'],
    mainFiles: ['index', 'main']
  },
  output: {
    path: __dirname + '/public/'
  },
  entry: {
    'main': './demos/src/demo'
  }
};
```