### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,6 +1,6 @@
-/*global describe, it, before, after, sinon */
+/* eslint-env mocha */
+/* global proclaim sinon */
 
-import assert from 'assert';
 import settings from '../src/javascript/core/settings';
 import Queue from '../src/javascript/core/queue';
 import session from '../src/javascript/core/session';
@@ -17,18 +17,18 @@ describe('Core', function () {
 
 		it('should generate a root_id', function () {
 			root_id = Core.setRootID();
-			assert.ok(root_id.match(guid_re), "'" + root_id + "'.match(" + guid_re + ")");
+			proclaim.ok(root_id.match(guid_re), "'" + root_id + "'.match(" + guid_re + ")");
 		});
 
 		it('should use the previous root_id for subsequent calls', function () {
-			assert.equal(Core.getRootID(), root_id);
-			assert.equal(Core.getRootID(), root_id);
+			proclaim.equal(Core.getRootID(), root_id);
+			proclaim.equal(Core.getRootID(), root_id);
 		});
 
 		it('should change the root_id on request', function () {
 			const new_root_id = Core.setRootID();
-			assert.equal(Core.getRootID(), new_root_id);
-			assert.notEqual(new_root_id, root_id);
+			proclaim.equal(Core.getRootID(), new_root_id);
+			proclaim.notEqual(new_root_id, root_id);
 		});
 	});
 
@@ -59,30 +59,30 @@ describe('Core', function () {
 				user: { "user_id": "userID" }
 			}, callback);
 
-			assert.ok(callback.called, 'Callback not called.');
+			proclaim.ok(callback.called, 'Callback not called.');
 
 			sent_data = callback.getCall(0).thisValue;
-			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+			proclaim.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 			// System
-			assert.deepEqual(Object.keys(sent_data.system), ["api_key","version","source"]);
-			assert.equal(sent_data.system.api_key, "qUb9maKfKbtpRsdp0p2J7uWxRPGJEP");
-			assert.equal(sent_data.system.version, "1.0.0");
-			assert.equal(sent_data.system.source, "o-tracking");
+			proclaim.deepEqual(Object.keys(sent_data.system), ["api_key","version","source"]);
+			proclaim.equal(sent_data.system.api_key, "qUb9maKfKbtpRsdp0p2J7uWxRPGJEP");
+			proclaim.equal(sent_data.system.version, "1.0.0");
+			proclaim.equal(sent_data.system.source, "o-tracking");
 
 			// Context
-			assert.deepEqual(Object.keys(sent_data.context), ["id","root_id","url"]);
-			assert.ok(guid_re.test(sent_data.context.id), "Request ID is invalid. " + sent_data.context.id);
-			assert.equal(sent_data.context.root_id, root_id);
-			assert.equal(sent_data.context.url, "http://www.ft.com/home/uk");
+			proclaim.deepEqual(Object.keys(sent_data.context), ["id","root_id","url"]);
+			proclaim.ok(guid_re.test(sent_data.context.id), "Request ID is invalid. " + sent_data.context.id);
+			proclaim.equal(sent_data.context.root_id, root_id);
+			proclaim.equal(sent_data.context.url, "http://www.ft.com/home/uk");
 
 			// User
-			assert.deepEqual(Object.keys(sent_data.user), ["passport_id","ft_session","ft_session_s","user_id"]);
-			assert.equal(sent_data.user.user_id, "userID");
+			proclaim.deepEqual(Object.keys(sent_data.user), ["passport_id","ft_session","ft_session_s","user_id"]);
+			proclaim.equal(sent_data.user.user_id, "userID");
 
 			// Device
-			assert.deepEqual(Object.keys(sent_data.device), ["spoor_session","spoor_session_is_new","spoor_id"]);
-			assert.equal(sent_data.device.spoor_session, session.session().id);
-			assert.equal(sent_data.device.spoor_session_is_new, session.session().isNew);
+			proclaim.deepEqual(Object.keys(sent_data.device), ["spoor_session","spoor_session_is_new","spoor_id"]);
+			proclaim.equal(sent_data.device.spoor_session, session.session().id);
+			proclaim.equal(sent_data.device.spoor_session_is_new, session.session().isNew);
 
 		});
 
@@ -98,12 +98,12 @@ describe('Core', function () {
 				user: { "userID": "userID" }
 			}, callback);
 
-			assert.equal(callback.called, 1, 'Callback called once.');
+			proclaim.equal(callback.called, 1, 'Callback called once.');
 
 			// Try again
 			send.run();
 
-			assert.ok(callback.calledOnce, 'Callback should only be called once as next send could be on a different page.');
+			proclaim.ok(callback.calledOnce, 'Callback should only be called once as next send could be on a different page.');
 		});
 	});
 

--- a/test/core/queue.test.js
+++ b/test/core/queue.test.js
@@ -1,6 +1,7 @@
-/*global describe, it */
+/* eslint-env mocha */
+/* global proclaim */
 
-import assert from 'assert';
+
 import Queue from '../../src/javascript/core/queue';
 const queue_name = 'queue_test';
 
@@ -11,7 +12,7 @@ describe('Core.Queue', function () {
 
 	describe('init()', function () {
 		it('should require a name', function () {
-			assert.throws(function () {
+			proclaim.throws(function () {
 				new Queue();
 			}, /You must specify a name for the queue/);
 		});
@@ -22,19 +23,19 @@ describe('Core.Queue', function () {
 
 	describe('add', function () {
 		it('should add a string to the queue', function () {
-			assert.doesNotThrow(function () {
+			proclaim.doesNotThrow(function () {
 				queue.add("hello");
 			});
 		});
 
 		it('should add an object to the queue', function () {
-			assert.doesNotThrow(function () {
+			proclaim.doesNotThrow(function () {
 				queue.add({ "hello": "world" });
 			});
 		});
 
 		it('should add many items at once', function () {
-			assert.doesNotThrow(function () {
+			proclaim.doesNotThrow(function () {
 				queue.add(['www.example.com', a_function]);
 			});
 		});
@@ -42,27 +43,27 @@ describe('Core.Queue', function () {
 
 	describe('retrieve', function () {
 		it('should have the correct number of items', function () {
-			assert.equal(queue.all().length, 4);
+			proclaim.equal(queue.all().length, 4);
 		});
 
 		it('should get the first item', function () {
-			assert.equal(queue.first(), "hello");
+			proclaim.equal(queue.first(), "hello");
 		});
 
 		it('should get the last item', function () {
-			assert.equal(queue.last(), a_function);
+			proclaim.equal(queue.last(), a_function);
 		});
 	});
 
 	describe('replace', function () {
 		it('should replace the queue', function () {
-			assert.doesNotThrow(function () {
+			proclaim.doesNotThrow(function () {
 				queue.replace(["i", 'am', /the/, function () { return 'replacement'; }]);
 			});
 		});
 
 		it('should have the correct number of items', function () {
-			assert.equal(queue.all().length, 4);
+			proclaim.equal(queue.all().length, 4);
 		});
 	});
 
@@ -70,17 +71,17 @@ describe('Core.Queue', function () {
 		it('should shift an item off the front of the queue', function () {
 			const pre_shift = queue.all();
 			const item = queue.shift();
-			assert.deepEqual(pre_shift, [item].concat(queue.all()));
+			proclaim.deepEqual(pre_shift, [item].concat(queue.all()));
 		});
 
 		it('should have the correct number of items', function () {
-			assert.equal(queue.all().length, 3);
+			proclaim.equal(queue.all().length, 3);
 		});
 	});
 
 	describe('saving', function () {
 		it('should persist the queue', function () {
-			assert.doesNotThrow(function () {
+			proclaim.doesNotThrow(function () {
 				queue.save();
 			});
 		});
@@ -88,13 +89,13 @@ describe('Core.Queue', function () {
 		let queue2;
 
 		it('should get the saved queue', function () {
-			assert.doesNotThrow(function () {
+			proclaim.doesNotThrow(function () {
 				queue2 = new Queue(queue_name);
 			});
 		});
 
 		it('should have the correct number of items', function () {
-			assert.equal(queue2.all().length, 3);
+			proclaim.equal(queue2.all().length, 3);
 		});
 	});
 });

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -1,6 +1,6 @@
-/*global describe, it, after, sinon, before */
+/* eslint-env mocha */
+/* global proclaim sinon */
 
-import assert from 'assert';
 import Send from '../../src/javascript/core/send';
 import Queue from "../../src/javascript/core/queue";
 
@@ -40,13 +40,13 @@ describe('Core.Send', function () {
 	});
 
 	it('should init first', function () {
-		assert.doesNotThrow(function () {
+		proclaim.doesNotThrow(function () {
 			Send.init();
 		});
 	});
 
 	it('should add a request', function () {
-		assert.doesNotThrow(function () {
+		proclaim.doesNotThrow(function () {
 			Send.add(request);
 		});
 	});
@@ -76,15 +76,15 @@ describe('Core.Send', function () {
 			};
 			Send.addAndRun(request);
 			setTimeout(() => {
-				assert.equal(typeof dummyXHR.onerror, 'function');
-				assert.equal(typeof dummyXHR.onload, 'function');
-				// assert.equal(dummyXHR.onerror.length, 1) // it will get passed the error
-				// assert.equal(dummyXHR.onload.length, 0) // it will not get passed an error
-				assert.ok(dummyXHR.withCredentials);
+				proclaim.equal(typeof dummyXHR.onerror, 'function');
+				proclaim.equal(typeof dummyXHR.onload, 'function');
+				// proclaim.equal(dummyXHR.onerror.length, 1) // it will get passed the error
+				// proclaim.equal(dummyXHR.onload.length, 0) // it will not get passed an error
+				proclaim.ok(dummyXHR.withCredentials);
 
-				assert.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/px.gif?type=video:seek", true));
-				assert.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'));
-				assert.ok(dummyXHR.send.calledOnce);
+				proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/px.gif?type=video:seek", true));
+				proclaim.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'));
+				proclaim.ok(dummyXHR.send.calledOnce);
 				window.XMLHttpRequest = xhr;
 				if (typeof navigator.sendBeacon === 'boolean') {
 					delete navigator.sendBeacon;
@@ -100,8 +100,8 @@ describe('Core.Send', function () {
 				Send.init();
 				Send.addAndRun(request);
 				setTimeout(() => {
-					assert.equal(navigator.sendBeacon.args[0][0], 'https://spoor-api.ft.com/px.gif?type=video:seek');
-					assert.ok(navigator.sendBeacon.called);
+					proclaim.equal(navigator.sendBeacon.args[0][0], 'https://spoor-api.ft.com/px.gif?type=video:seek');
+					proclaim.ok(navigator.sendBeacon.called);
 					navigator.sendBeacon.restore();
 					settings.destroy('config');
 					done();
@@ -128,14 +128,14 @@ describe('Core.Send', function () {
 			};
 			Send.addAndRun(request);
 			setTimeout(() => {
-				assert.equal(typeof dummyXHR.onerror, 'function');
-				assert.equal(typeof dummyXHR.onload, 'function');
-				// assert.equal(dummyXHR.onerror.length, 1) // it will get passed the error
-				// assert.equal(dummyXHR.onload.length, 0) // it will not get passed an error
-				assert.ok(dummyXHR.withCredentials, 'withCredentials');
-				assert.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/px.gif?type=video:seek", true), 'is POST');
-				assert.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'), 'is application/json');
-				assert.ok(dummyXHR.send.calledOnce, 'calledOnce');
+				proclaim.equal(typeof dummyXHR.onerror, 'function');
+				proclaim.equal(typeof dummyXHR.onload, 'function');
+				// proclaim.equal(dummyXHR.onerror.length, 1) // it will get passed the error
+				// proclaim.equal(dummyXHR.onload.length, 0) // it will not get passed an error
+				proclaim.ok(dummyXHR.withCredentials, 'withCredentials');
+				proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/px.gif?type=video:seek", true), 'is POST');
+				proclaim.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'), 'is application/json');
+				proclaim.ok(dummyXHR.send.calledOnce, 'calledOnce');
 				window.XMLHttpRequest = xhr;
 				navigator.sendBeacon = b;
 				settings.destroy('config');
@@ -159,11 +159,11 @@ describe('Core.Send', function () {
 			window.Image = sinon.stub().returns(dummyImage);
 			Send.addAndRun(request);
 			setTimeout(() => {
-				assert.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
-				assert.equal(dummyImage.addEventListener.args[0][0], 'error');
-				assert.equal(dummyImage.addEventListener.args[0][1].length, 1);// it will get passed the error
-				assert.equal(dummyImage.addEventListener.args[1][0], 'load');
-				assert.equal(dummyImage.addEventListener.args[1][1].length, 0);// it will get passed the error
+				proclaim.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
+				proclaim.equal(dummyImage.addEventListener.args[0][0], 'error');
+				proclaim.equal(dummyImage.addEventListener.args[0][1].length, 1);// it will get passed the error
+				proclaim.equal(dummyImage.addEventListener.args[1][0], 'load');
+				proclaim.equal(dummyImage.addEventListener.args[1][1].length, 0);// it will get passed the error
 				window.XMLHttpRequest = xhr;
 				window.Image = i;
 				navigator.sendBeacon = b;
@@ -186,11 +186,11 @@ describe('Core.Send', function () {
 			window.Image = sinon.stub().returns(dummyImage);
 			Send.addAndRun(request);
 			setTimeout(() => {
-				assert.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
-				assert.equal(dummyImage.attachEvent.args[0][0], 'onerror');
-				assert.equal(dummyImage.attachEvent.args[0][1].length, 1);// it will get passed the error
-				assert.equal(dummyImage.attachEvent.args[1][0], 'onload');
-				assert.equal(dummyImage.attachEvent.args[1][1].length, 0);// it will get passed the error
+				proclaim.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
+				proclaim.equal(dummyImage.attachEvent.args[0][0], 'onerror');
+				proclaim.equal(dummyImage.attachEvent.args[0][1].length, 1);// it will get passed the error
+				proclaim.equal(dummyImage.attachEvent.args[1][0], 'onload');
+				proclaim.equal(dummyImage.attachEvent.args[1][1].length, 0);// it will get passed the error
 				window.XMLHttpRequest = xhr;
 				window.Image = i;
 				navigator.sendBeacon = b;
@@ -221,7 +221,7 @@ describe('Core.Send', function () {
 			setTimeout(() => {
 				// console.log((new Queue('requests')).all());
 
-				assert.ok((new Queue('requests')).last().queueTime);
+				proclaim.ok((new Queue('requests')).last().queueTime);
 				navigator.sendBeacon = b;
 				server.restore();
 				done();
@@ -253,7 +253,7 @@ describe('Core.Send', function () {
 			// Wait for localStorage
 			setTimeout(() => {
 				// console.log((new Queue('requests')).all());
-				assert.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22xhr-image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
+				proclaim.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22xhr-image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
 
 				window.Image = i;
 				server.restore();
@@ -289,7 +289,7 @@ describe('Core.Send', function () {
 			queue = new Queue('requests');
 
 			// Event added for the debugging info
-			assert.equal(queue.all().length, 0);
+			proclaim.equal(queue.all().length, 0);
 
 			// console.log(queue.all());
 			server.restore();

--- a/test/core/session.test.js
+++ b/test/core/session.test.js
@@ -1,6 +1,6 @@
-/*global describe, it, beforeEach, afterEach */
+/* eslint-env mocha */
+/* global proclaim */
 
-import assert from 'assert';
 import Store from '../../src/javascript/core/store';
 import Session from '../../src/javascript/core/session';
 
@@ -17,15 +17,15 @@ describe('Core.Session', function () {
 
 	describe('no preset value', function () {
 		it('should init', function () {
-			assert.doesNotThrow(function () {
+			proclaim.doesNotThrow(function () {
 				Session.init();
 			});
 		});
 
 		it('should use generate an ID if one does not exist', function () {
 			const session = Session.init();
-			assert.notEqual(session.id, null);
-			assert.equal(session.isNew, true);
+			proclaim.notEqual(session.id, null);
+			proclaim.equal(session.isNew, true);
 		});
 	});
 
@@ -33,8 +33,8 @@ describe('Core.Session', function () {
 		it('should use the existing value until it expires.', function () {
 			const session = Session.init();
 			const newSession = Session.session();
-			assert.equal(newSession.id, session.id);
-			assert.equal(newSession.isNew, false);
+			proclaim.equal(newSession.id, session.id);
+			proclaim.equal(newSession.isNew, false);
 		});
 	});
 

--- a/test/core/settings.test.js
+++ b/test/core/settings.test.js
@@ -1,30 +1,30 @@
-/*global describe, it */
+/* eslint-env mocha */
+/* global proclaim */
 
-import assert from 'assert';
 import Settings from '../../src/javascript/core/settings';
 
 describe('Core.Settings', function () {
 
 	it('should set a value', function () {
-		assert.doesNotThrow(function () {
+		proclaim.doesNotThrow(function () {
 			Settings.set('key', 'value');
 			Settings.set('key2', 'value2');
 		});
 	});
 
 	it('should get a value', function () {
-		assert.equal(Settings.get('key'), 'value');
+		proclaim.equal(Settings.get('key'), 'value');
 	});
 
 	it('should delete a value', function () {
-		assert.doesNotThrow(function () {
+		proclaim.doesNotThrow(function () {
 			Settings.destroy('key');
 		});
-		assert.ok(typeof Settings.get('key') === "undefined");
+		proclaim.ok(typeof Settings.get('key') === "undefined");
 	});
 
 	it("should work between different require'd files.", function () {
-		assert.equal(Settings.get('key2'), "value2");
+		proclaim.equal(Settings.get('key2'), "value2");
 	});
 
 	it("should return a copy of an object to prevent mutating the store.", function () {
@@ -34,7 +34,7 @@ describe('Core.Settings', function () {
 
 		Settings.set('obj', obj);
 		obj.key = 'value2';
-		assert.equal(Settings.get('obj').key, 'value1');
+		proclaim.equal(Settings.get('obj').key, 'value1');
 	});
 
 	it("should return a copy of an array to prevent mutating the store.", function () {
@@ -42,8 +42,8 @@ describe('Core.Settings', function () {
 
 		Settings.set('arr', arr);
 		arr[0] = 'value2';
-		assert.equal(Settings.get('arr')[0], 'value1');
-		assert.equal(Object.prototype.toString.call(Settings.get('arr')), '[object Array]');
+		proclaim.equal(Settings.get('arr')[0], 'value1');
+		proclaim.equal(Object.prototype.toString.call(Settings.get('arr')), '[object Array]');
 	});
 
 });

--- a/test/core/store.test.js
+++ b/test/core/store.test.js
@@ -1,6 +1,6 @@
-/*global describe, it, document, navigator */
+/* eslint-env mocha */
+/* global proclaim */
 
-import assert from 'assert';
 import Store from '../../src/javascript/core/store';
 
 describe('Core.Store', function () {
@@ -8,16 +8,16 @@ describe('Core.Store', function () {
 	describe('init()', function () {
 
 		it('should use local storage by default', function () {
-			assert.equal((new Store('test')).storage._type, 'localStorage');
+			proclaim.equal((new Store('test')).storage._type, 'localStorage');
 		});
 
 		if (document.location.toString().match('^file://') && navigator.userAgent.indexOf('PhantomJS') > -1) {
 			it('should still work if there is no storage mechanism available', function () {
-				assert.equal((new Store('test', { storage: 'cookie' })).storage._type, 'none');
+				proclaim.equal((new Store('test', { storage: 'cookie' })).storage._type, 'none');
 			});
 		} else {
 			it('can use cookies for storage', function () {
-				assert.equal((new Store('test', { storage: 'cookie' })).storage._type, 'cookie');
+				proclaim.equal((new Store('test', { storage: 'cookie' })).storage._type, 'cookie');
 			});
 		}
 	});
@@ -26,13 +26,13 @@ describe('Core.Store', function () {
 
 	describe('write()', function () {
 		it('should save a value', function () {
-			assert.equal(store.write('TESTING').read(), 'TESTING');
+			proclaim.equal(store.write('TESTING').read(), 'TESTING');
 		});
 	});
 
 	describe('read()', function () {
 		it('should retrieve a value', function () {
-			assert.equal(store.read(), 'TESTING');
+			proclaim.equal(store.read(), 'TESTING');
 		});
 	});
 
@@ -43,7 +43,7 @@ describe('Core.Store', function () {
 			cookie_store.write(['one', 'two']);
 
 			cookie_store = new Store('test-cookies', { storage: 'cookie' });
-			assert.deepEqual(cookie_store.read(), ['one', 'two']);
+			proclaim.deepEqual(cookie_store.read(), ['one', 'two']);
 		});
 	});
 

--- a/test/core/user.test.js
+++ b/test/core/user.test.js
@@ -1,6 +1,6 @@
-/*global describe, it, afterEach */
+/* eslint-env mocha */
+/* global proclaim */
 
-import assert from 'assert';
 import User from '../../src/javascript/core/user';
 
 describe('Core.User', function () {
@@ -13,13 +13,13 @@ describe('Core.User', function () {
 
 	describe('no preset value', function () {
 		it('should init', function () {
-			assert.doesNotThrow(function () {
+			proclaim.doesNotThrow(function () {
 				userID = User.init();
 			});
 		});
 
 		it('should use generate an ID if one does not exist', function () {
-			assert.equal(User.userID(), userID);
+			proclaim.equal(User.userID(), userID);
 		});
 	});
 
@@ -29,7 +29,7 @@ describe('Core.User', function () {
 		});
 
 		it('should retrieve the userID ', function () {
-			assert.equal(User.userID(), 'value1');
+			proclaim.equal(User.userID(), 'value1');
 		});
 
 		it('should use a string', function () {
@@ -37,7 +37,7 @@ describe('Core.User', function () {
 		});
 
 		it('should retrieve the userID ', function () {
-			assert.equal(User.userID(), 'value2');
+			proclaim.equal(User.userID(), 'value2');
 		});
 	});
 
@@ -45,7 +45,7 @@ describe('Core.User', function () {
 		it('should use the existing value, even if a new one is provided.', function () {
 			User.init('value2');
 			User.init('value3');
-			assert.equal(User.userID(), 'value2');
+			proclaim.equal(User.userID(), 'value2');
 		});
 	});
 

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -1,6 +1,8 @@
-/*global describe, it, before, after, sinon, document */
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import '../setup';
-import assert from 'assert';
+
 import Queue from '../../src/javascript/core/queue';
 import settings from '../../src/javascript/core/settings';
 import send from '../../src/javascript/core/send';
@@ -58,7 +60,7 @@ describe('click', function () {
 
 		setTimeout(() => {
 
-			assert.equal(core.track.calledOnce, true, "click event tracked");
+			proclaim.equal(core.track.calledOnce, true, "click event tracked");
 
 			core.track.restore();
 			done();
@@ -94,7 +96,7 @@ describe('click', function () {
 		aLinkToGoogle.dispatchEvent(event, true);
 
 		setTimeout(() => {
-			assert.equal(core.track.getCall(0).args[0].context.foo, 'bar');
+			proclaim.equal(core.track.getCall(0).args[0].context.foo, 'bar');
 
 			core.track.restore();
 			done();
@@ -130,7 +132,7 @@ describe('click', function () {
 
 		setTimeout(() => {
 
-			assert.equal(core.track.notCalled, true, "click event not tracked");
+			proclaim.equal(core.track.notCalled, true, "click event not tracked");
 
 			core.track.restore();
 			done();
@@ -167,7 +169,7 @@ describe('click', function () {
 		aLinkToPageOnSameDomain.dispatchEvent(event, true);
 
 		setTimeout(() => {
-			assert.equal(core.track.notCalled, true, "click event not tracked");
+			proclaim.equal(core.track.notCalled, true, "click event not tracked");
 
 			core.track.restore();
 			done();
@@ -205,7 +207,7 @@ describe('click', function () {
 		aLinkToPageOnSameDomain.dispatchEvent(event, true);
 
 		setTimeout(() => {
-			assert.equal(core.track.calledOnce, true, "click event not tracked");
+			proclaim.equal(core.track.calledOnce, true, "click event not tracked");
 
 			core.track.restore();
 			done();

--- a/test/events/component-view.test.js
+++ b/test/events/component-view.test.js
@@ -1,6 +1,8 @@
-/*global describe, it, before, after, sinon, document */
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import '../setup';
-import assert from 'assert';
+
 import settings from '../../src/javascript/core/settings';
 import send from '../../src/javascript/core/send';
 import core from '../../src/javascript/core';
@@ -89,16 +91,16 @@ describe('component:view', () => {
 		});
 
 		it('should track an event for a component view ', () => {
-			assert.equal(errorThrown, undefined);
-			assert.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
-			assert.equal(unobserveSpy.calledOnce, true, 'IntersectionObserver unobserved target');
-			assert.equal(core.track.calledOnce, true, 'view event tracked');
+			proclaim.equal(errorThrown, undefined);
+			proclaim.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
+			proclaim.equal(unobserveSpy.calledOnce, true, 'IntersectionObserver unobserved target');
+			proclaim.equal(core.track.calledOnce, true, 'view event tracked');
 		});
 
 		it('should track with correct detail', () => {
-			assert.equal(core.track.getCall(0).args[0].category, 'component');
-			assert.equal(core.track.getCall(0).args[0].action, 'view');
-			assert.ok(core.track.getCall(0).args[0].context.domPathTokens, true);
+			proclaim.equal(core.track.getCall(0).args[0].category, 'component');
+			proclaim.equal(core.track.getCall(0).args[0].action, 'view');
+			proclaim.ok(core.track.getCall(0).args[0].context.domPathTokens, true);
 		});
 	});
 
@@ -133,20 +135,20 @@ describe('component:view', () => {
 			});
 
 			it('should track an event for a component view', () => {
-				assert.equal(errorThrown, undefined);
-				assert.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
-				assert.equal(unobserveSpy.calledOnce, true, 'IntersectionObserver unobserved target');
-				assert.equal(core.track.calledOnce, true, 'view event tracked');
+				proclaim.equal(errorThrown, undefined);
+				proclaim.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
+				proclaim.equal(unobserveSpy.calledOnce, true, 'IntersectionObserver unobserved target');
+				proclaim.equal(core.track.calledOnce, true, 'view event tracked');
 			});
 
 			it('should track with correct detail', () => {
 				const trackedDetail = core.track.getCall(0).args[0];
 
-				assert.equal(trackedDetail.category, category);
-				assert.equal(trackedDetail.action, 'view');
-				assert.ok(trackedDetail.context.domPathTokens, true);
-				assert.equal(trackedDetail.context.componentContentId, id);
-				assert.equal(trackedDetail.context.type, type);
+				proclaim.equal(trackedDetail.category, category);
+				proclaim.equal(trackedDetail.action, 'view');
+				proclaim.ok(trackedDetail.context.domPathTokens, true);
+				proclaim.equal(trackedDetail.context.componentContentId, id);
+				proclaim.equal(trackedDetail.context.type, type);
 			});
 		});
 
@@ -163,10 +165,10 @@ describe('component:view', () => {
 				});
 
 				it('should throw an error', () => {
-					assert.equal(errorThrown.message, 'opts.getContextData is not a function');
-					assert.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
-					assert.equal(unobserveSpy.calledOnce, false, 'IntersectionObserver unobserved target');
-					assert.equal(core.track.calledOnce, false, 'view event tracked');
+					proclaim.equal(errorThrown.message, 'opts.getContextData is not a function');
+					proclaim.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
+					proclaim.equal(unobserveSpy.calledOnce, false, 'IntersectionObserver unobserved target');
+					proclaim.equal(core.track.calledOnce, false, 'view event tracked');
 				});
 			});
 
@@ -182,10 +184,10 @@ describe('component:view', () => {
 				});
 
 				it('should throw an error', () => {
-					assert.equal(errorThrown.message, 'opts.getContextData function should return {Object}');
-					assert.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
-					assert.equal(unobserveSpy.calledOnce, false, 'IntersectionObserver unobserved target');
-					assert.equal(core.track.calledOnce, false, 'view event tracked');
+					proclaim.equal(errorThrown.message, 'opts.getContextData function should return {Object}');
+					proclaim.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
+					proclaim.equal(unobserveSpy.calledOnce, false, 'IntersectionObserver unobserved target');
+					proclaim.equal(core.track.calledOnce, false, 'view event tracked');
 				});
 			});
 
@@ -206,17 +208,17 @@ describe('component:view', () => {
 				});
 
 				it('should not throw an error', () => {
-					assert.equal(errorThrown, undefined);
-					assert.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
-					assert.equal(unobserveSpy.calledOnce, true, 'IntersectionObserver unobserved target');
-					assert.equal(core.track.calledOnce, true, 'view event tracked');
+					proclaim.equal(errorThrown, undefined);
+					proclaim.equal(observeSpy.calledOnce, true, 'IntersectionObserver observed target');
+					proclaim.equal(unobserveSpy.calledOnce, true, 'IntersectionObserver unobserved target');
+					proclaim.equal(core.track.calledOnce, true, 'view event tracked');
 				});
 
 				it('should not have non-whitelist props in event detail', () => {
 					const trackedDetail = core.track.getCall(0).args[0];
 
-					assert.equal(trackedDetail.context.componentContentId, id);
-					assert.equal(trackedDetail.context.name, undefined);
+					proclaim.equal(trackedDetail.context.componentContentId, id);
+					proclaim.equal(trackedDetail.context.name, undefined);
 				});
 			});
 

--- a/test/events/custom.test.js
+++ b/test/events/custom.test.js
@@ -1,6 +1,8 @@
-/*global describe, it, before, after, sinon */
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import '../setup';
-import assert from 'assert';
+
 import Queue from '../../src/javascript/core/queue';
 import settings from '../../src/javascript/core/settings';
 import send from '../../src/javascript/core/send';
@@ -35,18 +37,18 @@ describe('event', function () {
 			}
 		}), callback);
 
-		assert.ok(callback.called, 'Callback not called.');
+		proclaim.ok(callback.called, 'Callback not called.');
 
 		sent_data = callback.getCall(0).thisValue;
 
-		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+		proclaim.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
 		// Event
-		assert.equal(sent_data.category, "slideshow");
-		assert.equal(sent_data.action, "slide_viewed");
-		assert.equal(sent_data.context.slide_number, 5);
-		assert.equal(sent_data.context.component_id, "123456");
-		assert.equal(sent_data.context.component_name, 'custom-o-tracking');
+		proclaim.equal(sent_data.category, "slideshow");
+		proclaim.equal(sent_data.action, "slide_viewed");
+		proclaim.equal(sent_data.context.slide_number, 5);
+		proclaim.equal(sent_data.context.component_id, "123456");
+		proclaim.equal(sent_data.context.component_name, 'custom-o-tracking');
 	});
 
 	it('should listen to a dom event and generate a component_id', function () {
@@ -66,19 +68,19 @@ describe('event', function () {
 			const callback = sinon.spy();
 
 			trackEvent(e, callback);
-			assert.ok(callback.called, 'Callback not called.');
+			proclaim.ok(callback.called, 'Callback not called.');
 
 			const sent_data = callback.getCall(0).thisValue;
 
-			assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+			proclaim.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
 			// Event
-			assert.equal(sent_data.category, "video");
-			assert.equal(sent_data.action, "play");
-			assert.equal(sent_data.context.key, 'id');
-			assert.equal(sent_data.context.value, 51234);
-			assert.equal(typeof sent_data.context.component_id, "number");
-			assert.equal(sent_data.context.component_name, "o-tracking");
+			proclaim.equal(sent_data.category, "video");
+			proclaim.equal(sent_data.action, "play");
+			proclaim.equal(sent_data.context.key, 'id');
+			proclaim.equal(sent_data.context.value, 51234);
+			proclaim.equal(typeof sent_data.context.component_id, "number");
+			proclaim.equal(sent_data.context.component_name, "o-tracking");
 
 		});
 

--- a/test/events/page.test.js
+++ b/test/events/page.test.js
@@ -1,6 +1,8 @@
-/*global describe, it, before, beforeEach, after, sinon */
+/* eslint-env mocha */
+/* global proclaim sinon */
+
 import '../setup';
-import assert from 'assert';
+
 import settings from '../../src/javascript/core/settings';
 import send from '../../src/javascript/core/send';
 import session from '../../src/javascript/core/session';
@@ -33,21 +35,21 @@ describe('page', function () {
 		page({
 			url: "http://www.ft.com/home/uk"
 		}, callback);
-		assert.ok(callback.called, 'Callback not called.');
+		proclaim.ok(callback.called, 'Callback not called.');
 
 		sent_data = callback.getCall(0).thisValue;
 		// Basics
-		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
-		assert.deepEqual(Object.keys(sent_data.context), ["id","root_id","url","referrer"]);
+		proclaim.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+		proclaim.deepEqual(Object.keys(sent_data.context), ["id","root_id","url","referrer"]);
 
 		// Type
-		assert.equal(sent_data.category, "page");
-		assert.equal(sent_data.action, "view");
+		proclaim.equal(sent_data.category, "page");
+		proclaim.equal(sent_data.action, "view");
 
 		// Page
-		assert.equal(sent_data.context.url, "http://www.ft.com/home/uk");
+		proclaim.equal(sent_data.context.url, "http://www.ft.com/home/uk");
 		/*eslint-disable*/
-		assert.ok((sent_data.context.referrer != null), "referrer is invalid. " + sent_data.context.referrer);
+		proclaim.ok((sent_data.context.referrer != null), "referrer is invalid. " + sent_data.context.referrer);
 		/*eslint-enable*/
 	});
 
@@ -62,27 +64,27 @@ describe('page', function () {
 		page({
 			url: "http://www.ft.com/home/uk"
 		}, callback);
-		assert.ok(callback.called, 'Callback not called.');
+		proclaim.ok(callback.called, 'Callback not called.');
 
 		page1_root_id = callback.getCall(0).thisValue.context.root_id;
 
 		page({
 			url: "http://www.ft.com/home/uk"
 		}, callback2);
-		assert.ok(callback2.called, 'Callback not called.');
+		proclaim.ok(callback2.called, 'Callback not called.');
 
 		page2_root_id = callback2.getCall(0).thisValue.context.root_id;
 
 		page({
 			url: "http://www.ft.com/home/uk"
 		}, callback3);
-		assert.ok(callback3.called, 'Callback not called.');
+		proclaim.ok(callback3.called, 'Callback not called.');
 
 		page3_root_id = callback3.getCall(0).thisValue.context.root_id;
 
-		assert.notEqual(page1_root_id, page2_root_id, 'root_id is not unique');
-		assert.notEqual(page2_root_id, page3_root_id, 'root_id is not unique');
-		assert.notEqual(page1_root_id, page3_root_id, 'root_id is not unique');
+		proclaim.notEqual(page1_root_id, page2_root_id, 'root_id is not unique');
+		proclaim.notEqual(page2_root_id, page3_root_id, 'root_id is not unique');
+		proclaim.notEqual(page1_root_id, page3_root_id, 'root_id is not unique');
 	});
 
 	it('should have an event sent before a PV attached to the next PV sent', function () {
@@ -97,16 +99,16 @@ describe('page', function () {
 				action: 'click'
 			}
 		}), callback);
-		assert.ok(callback.called, 'Callback not called.');
+		proclaim.ok(callback.called, 'Callback not called.');
 
 		event_root_id = callback.getCall(0).thisValue.context.root_id;
 
 		page({
 			url: "http://www.ft.com/home/uk"
 		}, callback2);
-		assert.ok(callback2.called, 'Callback not called.');
+		proclaim.ok(callback2.called, 'Callback not called.');
 
 		page_root_id = callback2.getCall(0).thisValue.context.root_id;
-		assert.equal(event_root_id, page_root_id, 'root_id should match: ' + event_root_id + '===' + page_root_id);
+		proclaim.equal(event_root_id, page_root_id, 'root_id should match: ' + event_root_id + '===' + page_root_id);
 	});
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,7 +1,8 @@
-/*global describe, it, before, after, sinon */
+/* eslint-env mocha */
+/* global proclaim sinon */
 
 import './setup';
-import assert from 'assert';
+
 import settings from '../src/javascript/core/settings';
 import Queue from '../src/javascript/core/queue';
 import Send from '../src/javascript/core/send';
@@ -21,7 +22,7 @@ describe('main', function () {
 	it('should quit without any config to init with', function() {
 		oTracking.destroy();
 		const tracking = oTracking.init();
-		assert.equal(tracking, null);
+		proclaim.equal(tracking, null);
 		oTracking.destroy();
 	});
 
@@ -42,8 +43,8 @@ describe('main', function () {
 		document.head.appendChild(confEl);
 		const tracking = oTracking.init();
 
-		assert.deepEqual(settings.get('config'), config);
-		assert.equal(tracking.initialised, true);
+		proclaim.deepEqual(settings.get('config'), config);
+		proclaim.equal(tracking.initialised, true);
 
 		document.head.removeChild(confEl);
 		oTracking.destroy();
@@ -66,30 +67,30 @@ describe('main', function () {
 			url: 'http://www.ft.com/cms/s/0/576f5f1c-0509-11e5-9627-00144feabdc0.html'
 		}, callback);
 
-		assert.ok(callback.called, 'Callback not called.');
+		proclaim.ok(callback.called, 'Callback not called.');
 
 		sent_data = callback.getCall(0).thisValue;
 
 		root_id = sent_data.context.root_id;
 
 		// Basics
-		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+		proclaim.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
 		// Meta
-		assert.equal(sent_data.system.api_key, "qUb9maKfKbtpRsdp0p2J7uWxRPGJEP");
-		assert.ok(sent_data.system.version.match(/\d+\.\d+.\d+/));
-		assert.equal(sent_data.system.source, "o-tracking");
+		proclaim.equal(sent_data.system.api_key, "qUb9maKfKbtpRsdp0p2J7uWxRPGJEP");
+		proclaim.ok(sent_data.system.version.match(/\d+\.\d+.\d+/));
+		proclaim.equal(sent_data.system.source, "o-tracking");
 
 		// Type
-		assert.equal(sent_data.category, "page");
-		assert.equal(sent_data.action, "view");
+		proclaim.equal(sent_data.category, "page");
+		proclaim.equal(sent_data.action, "view");
 
 		// User
-		assert.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
+		proclaim.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
 
 		// Page
-		assert.equal(sent_data.context.url, "http://www.ft.com/cms/s/0/576f5f1c-0509-11e5-9627-00144feabdc0.html");
-		assert.equal(sent_data.context.product, "desktop");
+		proclaim.equal(sent_data.context.url, "http://www.ft.com/cms/s/0/576f5f1c-0509-11e5-9627-00144feabdc0.html");
+		proclaim.equal(sent_data.context.product, "desktop");
 	});
 
 	it('should track an event', function () {
@@ -105,25 +106,25 @@ describe('main', function () {
 			}
 		}), callback);
 
-		assert.ok(callback.called, 'Callback not called.');
+		proclaim.ok(callback.called, 'Callback not called.');
 
 
 		sent_data = callback.getCall(0).thisValue;
 
 		// Basics
-		assert.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
+		proclaim.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 
 		// Type
-		assert.equal(sent_data.category, "video");
-		assert.equal(sent_data.action, "play");
-		assert.equal(sent_data.context.component_id, "123456");
+		proclaim.equal(sent_data.category, "video");
+		proclaim.equal(sent_data.action, "play");
+		proclaim.equal(sent_data.context.component_id, "123456");
 
 		// User
-		assert.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
+		proclaim.equal(sent_data.user.user_id, '023ur9jfokwenvcklwnfiwhfoi324');
 
 		// Page
-		assert.equal(sent_data.context.root_id, root_id);
-		assert.equal(sent_data.context.product, "desktop");
+		proclaim.equal(sent_data.context.root_id, root_id);
+		proclaim.equal(sent_data.context.product, "desktop");
 	});
 
 	it('should not mutate init config', function () {
@@ -137,18 +138,18 @@ describe('main', function () {
 			my_key: "my_val"
 		}, callback1);
 
-		assert.ok(callback1.called, 'Callback not called.');
+		proclaim.ok(callback1.called, 'Callback not called.');
 
 		sent_data1 = callback1.getCall(0).thisValue;
-		assert.equal(sent_data1.context.my_key, "my_val");
+		proclaim.equal(sent_data1.context.my_key, "my_val");
 
 		// Track another page
 		oTracking.page({}, callback2);
-		assert.ok(callback2.called, 'Callback not called.');
+		proclaim.ok(callback2.called, 'Callback not called.');
 
 		// Ensure vars from the first track don't leak into the second
 		sent_data2 = callback2.getCall(0).thisValue;
-		assert.equal(sent_data2.context.my_key, undefined);
+		proclaim.equal(sent_data2.context.my_key, undefined);
 	});
 
 	it('should allow system properties to be set on init', function () {
@@ -167,12 +168,12 @@ describe('main', function () {
 
 		oTracking.page({}, callback);
 
-		assert.ok(callback.called, 'Callback not called.');
+		proclaim.ok(callback.called, 'Callback not called.');
 
 		sent_data = callback.getCall(0).thisValue;
 
-		assert.equal(sent_data.system.environment, "prod");
-		assert.equal(sent_data.system.is_live, true);
+		proclaim.equal(sent_data.system.environment, "prod");
+		proclaim.equal(sent_data.system.is_live, true);
 	});
 
 	it('should allow config to be updated after init', function () {
@@ -199,15 +200,15 @@ describe('main', function () {
 			detail: { category: 'video', action: 'play', component_id: '12345' }
 		}), callback);
 
-		assert.ok(callback.called, 'Callback not called.');
+		proclaim.ok(callback.called, 'Callback not called.');
 
 		const data_one = callback.getCall(0).thisValue;
-		assert.equal(data_one.context.component_id, '12345');
-		assert.equal(data_one.context.marketing.segid, '1234');
-		assert.equal(data_one.device.orientation, 'landscape');
-		assert.equal(data_one.device.is_offline, true);
-		assert.equal(data_one.user.user_id, 'c2nb134j8hz2p');
-		assert.equal(Send.getDomain(), 'https://spoor-api.ft.com/px.gif');
+		proclaim.equal(data_one.context.component_id, '12345');
+		proclaim.equal(data_one.context.marketing.segid, '1234');
+		proclaim.equal(data_one.device.orientation, 'landscape');
+		proclaim.equal(data_one.device.is_offline, true);
+		proclaim.equal(data_one.user.user_id, 'c2nb134j8hz2p');
+		proclaim.equal(Send.getDomain(), 'https://spoor-api.ft.com/px.gif');
 
 		oTracking.updateConfig({
 			server: 'somewhere over the rainbow',
@@ -228,16 +229,16 @@ describe('main', function () {
 			detail: { category: 'video', action: 'play', component_id: '12346' }
 		}), callback);
 
-		assert.ok(callback.called, 'Callback not called.');
+		proclaim.ok(callback.called, 'Callback not called.');
 
 		const data_two = callback.getCall(1).thisValue;
-		assert.equal(data_two.context.component_id, '12346');
-		assert.equal(data_two.context.marketing.segid, '1234');
-		assert.equal(data_two.context.marketing.banner_closed, true);
-		assert.equal(data_two.device.orientation, 'portrait');
-		assert.equal(data_two.device.is_offline, true);
-		assert.equal(data_two.user.user_id, 'cjw30zh3bxei6');
-		assert.equal(Send.getDomain(), 'somewhere over the rainbow');
+		proclaim.equal(data_two.context.component_id, '12346');
+		proclaim.equal(data_two.context.marketing.segid, '1234');
+		proclaim.equal(data_two.context.marketing.banner_closed, true);
+		proclaim.equal(data_two.device.orientation, 'portrait');
+		proclaim.equal(data_two.device.is_offline, true);
+		proclaim.equal(data_two.user.user_id, 'cjw30zh3bxei6');
+		proclaim.equal(Send.getDomain(), 'somewhere over the rainbow');
 	});
 
 	it('should override core configuration with individual calls', function () {
@@ -254,15 +255,15 @@ describe('main', function () {
 			}
 		}), callback);
 
-		assert.ok(callback.called, 'Callback not called.');
+		proclaim.ok(callback.called, 'Callback not called.');
 
 		const data = callback.getCall(0).thisValue;
-		assert.equal(data.context.component_id, '12349');
-		assert.equal(data.context.marketing.banner_closed, true);
-		assert.equal(data.context.marketing.segid, '4321');
+		proclaim.equal(data.context.component_id, '12349');
+		proclaim.equal(data.context.marketing.banner_closed, true);
+		proclaim.equal(data.context.marketing.segid, '4321');
 	});
 
 	it('should have getRootId() as an accessible method', () => {
-		assert.equal(typeof oTracking.getRootID, 'function');
+		proclaim.equal(typeof oTracking.getRootID, 'function');
 	});
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,12 +1,12 @@
-/*global describe, it, sinon */
+/* eslint-env mocha */
+/* global proclaim sinon */
 
-import assert from 'assert';
 import Utils from '../src/javascript/utils';
 
 describe('Utils', function () {
 
 	it('should provide log functionality', function () {
-		assert.ok(Utils.log);
+		proclaim.ok(Utils.log);
 	});
 
 	it('should provide is functionality', function () {
@@ -21,53 +21,53 @@ describe('Utils', function () {
 			{ value: {}, answer: 'object' },
 			{ value: function () {}, answer: 'function' }
 		].forEach(function (test) {
-			assert.ok(Utils.is(test.value, test.answer), test.value + " is a " + test.answer);
+			proclaim.ok(Utils.is(test.value, test.answer), test.value + " is a " + test.answer);
 		});
 	});
 
 	it('should provide isUndefined functionality', function () {
-		assert.ok(Utils.isUndefined(undefined));
+		proclaim.ok(Utils.isUndefined(undefined));
 	});
 
 	it('should provide merge functionality', function () {
-		assert.deepEqual(Utils.merge({ 'one' : 'one'}, { 'two': 'two' }), { 'one' : 'one', 'two': 'two' });
+		proclaim.deepEqual(Utils.merge({ 'one' : 'one'}, { 'two': 'two' }), { 'one' : 'one', 'two': 'two' });
 	});
 
 	it('should provide encode functionality', function () {
-		assert.equal(Utils.encode('http://www.ft.com?foo=bar&testing=yay!'), "http%3A%2F%2Fwww.ft.com%3Ffoo%3Dbar%26testing%3Dyay!");
+		proclaim.equal(Utils.encode('http://www.ft.com?foo=bar&testing=yay!'), "http%3A%2F%2Fwww.ft.com%3Ffoo%3Dbar%26testing%3Dyay!");
 	});
 
 	it('should provide guid generation', function () {
 		const guid = Utils.guid();
 		const re = /^\w{25}$/; // cifnulwv2000030ds4avpbm9f
-		assert.ok(re.test(guid), 'Guid ' + guid + 'should match ' + /^\w{25}$/);
+		proclaim.ok(re.test(guid), 'Guid ' + guid + 'should match ' + /^\w{25}$/);
 	});
 
 	describe('internal page event', function () {
 		const callback = sinon.spy();
 
 		it('should provide onPage functionality', function () {
-			assert.doesNotThrow(function () {
+			proclaim.doesNotThrow(function () {
 				Utils.onPage(callback);
 			});
 		});
 
 		it('should call the callback when page is triggered', function () {
 			Utils.triggerPage();
-			assert.ok(callback.called, 'callback was triggered.');
+			proclaim.ok(callback.called, 'callback was triggered.');
 		});
 	});
 
 	it('should provide getValueFromCookie functionality', function () {
-		assert.ok(Utils.getValueFromCookie);
+		proclaim.ok(Utils.getValueFromCookie);
 	});
 
 	it('should provide getValueFromUrl functionality', function () {
-		assert.ok(Utils.getValueFromUrl);
+		proclaim.ok(Utils.getValueFromUrl);
 	});
 
 	it('should provide getValueFromJsVariable functionality', function () {
-		assert.ok(Utils.getValueFromJsVariable);
+		proclaim.ok(Utils.getValueFromJsVariable);
 	});
 
 	it('should provide sanitise functionality', function () {
@@ -75,7 +75,7 @@ describe('Utils', function () {
 			{ param: '   with space  ', result: 'with space' },
 			{ param: 'noSpace', result: 'noSpace' }
 	 	].forEach(function (test) {
-			assert.equal(Utils.sanitise(test.param), test.result);
+			proclaim.equal(Utils.sanitise(test.param), test.result);
 		});
 	});
 
@@ -88,7 +88,7 @@ describe('Utils', function () {
 			}
 		].forEach(function (test) {
 			Utils.assignIfUndefined(test.subject, test.target);
-			assert.deepEqual(test.target, test.result);
+			proclaim.deepEqual(test.target, test.result);
 		});
 	});
 
@@ -109,7 +109,7 @@ describe('Utils', function () {
 				result: {}
 			}
 		].forEach(function (test) {
-			assert.deepEqual(Utils.whitelistProps(test.target, whitelist), test.result);
+			proclaim.deepEqual(Utils.whitelistProps(test.target, whitelist), test.result);
 		});
 	});
 


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.