### PR TITLE
Refactor: rename whitelistProps to filterProperties and replace reduce with a for-of loop

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,16 @@
 
 # Migration
 
+## Migrating from v2 to v3
+
+The method `whitelistProps` has been renamed to `filterProperties`.
+
+
+```diff
+-Tracking.prototype.utils.whitelistProps
++Tracking.prototype.utils.filterProperties
+```
+
 ## Migrating from v1 to v2
 
 o-tracking v2 has dropped support for ftdomdelegate v3, please ensure your project is not using ftdomdelegate v3 and can work with ftdomdelegate v4.

--- a/README.md
+++ b/README.md
@@ -296,7 +296,8 @@ For example:
 
 | State | Major Version | Last Minor Release | Migration guide |
 | :---: | :---: | :---: | :---: |
-| ✨ active | 2 | N/A | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+| ✨ active | 3 | N/A | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+| ⚠ maintained | 2 | 2.0.10 | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
 | ╳ deprecated | 1 | 1.7.2 | N/A |
 
 ---

--- a/src/javascript/events/component-view.js
+++ b/src/javascript/events/component-view.js
@@ -19,13 +19,13 @@ const decorateEventData = (eventData, viewedEl, opts) => {
 			throw new Error('opts.getContextData is not a function');
 		}
 
-		const dataBeforeWhitelist = opts.getContextData(viewedEl);
+		const contextData = opts.getContextData(viewedEl);
 
-		if (typeof dataBeforeWhitelist !== 'object') {
+		if (typeof contextData !== 'object') {
 			throw new Error('opts.getContextData function should return {Object}');
 		}
 
-		context = utils.whitelistProps(dataBeforeWhitelist, TRACKING_ATTRIBUTES);
+		context = utils.filterProperties(contextData, TRACKING_ATTRIBUTES);
 	} else {
 		context = {};
 	}

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -210,20 +210,19 @@ function getValueFromJsVariable(str) {
 }
 
 /**
- * Whitelist props
- * @param {Object} props - An object whose props need to be whitelisted
- * @param {Array} list - A list for whitelisting
- * @return
+ * Filter an object to only have the properties which are listed in the `allowlist` parameter.
+ * @param {Object} objectToFilter - An object whose props need to be filtered
+ * @param {Array} allowedPropertyNames - The list of props to allow
+ * @return {Object} An object containing only the allowed props
  */
-function whitelistProps (props, list) {
-	return list.reduce(
-		(acc, propName) => Object.assign(
-			{},
-			acc,
-			props[propName] ? { [propName]: props[propName] } : undefined
-		),
-		{}
-	);
+function filterProperties (objectToFilter, allowedPropertyNames) {
+	const filteredObject = {};
+	for (const allowedName of allowedPropertyNames) {
+		if (objectToFilter[allowedName]) {
+			filteredObject[allowedName] = objectToFilter[allowedName];
+		}
+	}
+	return filteredObject;
 }
 
 /**
@@ -272,7 +271,7 @@ export default {
 	getValueFromJsVariable,
 	sanitise,
 	assignIfUndefined,
-	whitelistProps
+	filterProperties
 };
 export {
 	log,
@@ -291,5 +290,5 @@ export {
 	getValueFromJsVariable,
 	sanitise,
 	assignIfUndefined,
-	whitelistProps
+	filterProperties
 };

--- a/test/events/component-view.test.js
+++ b/test/events/component-view.test.js
@@ -191,7 +191,7 @@ describe('component:view', () => {
 				});
 			});
 
-			context('getContextData returns an Object includes non-whitelist props', () => {
+			context('getContextData returns an Object which includes unfiltered props', () => {
 				beforeEach(() => {
 					const opts = {
 						selector: `[${targetAttribute}]`,
@@ -214,7 +214,7 @@ describe('component:view', () => {
 					proclaim.equal(core.track.calledOnce, true, 'view event tracked');
 				});
 
-				it('should not have non-whitelist props in event detail', () => {
+				it('should not have unfiltered props in event detail', () => {
 					const trackedDetail = core.track.getCall(0).args[0];
 
 					proclaim.equal(trackedDetail.context.componentContentId, id);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -92,8 +92,8 @@ describe('Utils', function () {
 		});
 	});
 
-	it('should provide whitelistProps functionality', function () {
-		const whitelist = [ 'componentContentId', 'type' ];
+	it('should provide filterProperties functionality', function () {
+		const allowedPropertyNames = [ 'componentContentId', 'type' ];
 
 		[
 			{
@@ -109,7 +109,7 @@ describe('Utils', function () {
 				result: {}
 			}
 		].forEach(function (test) {
-			proclaim.deepEqual(Utils.whitelistProps(test.target, whitelist), test.result);
+			proclaim.deepEqual(Utils.filterProperties(test.target, allowedPropertyNames), test.result);
 		});
 	});
 


### PR DESCRIPTION
Rename variables and function to be more descriptive.

Replace reduce function which generates an object via Object.assign with a for-of loop.