### PR TITLE
When given a circular object to send to spoor, throw a custom error message that states circular objects are not supported 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
   ],
   "description": "Origami module for FT tracking.",
   "dependencies": {
-    "ftdomdelegate": "^4.0.0",
-    "is-circular": "tjmehta/is-circular#^1.0.2"
+    "ftdomdelegate": "^4.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,7 @@
   ],
   "description": "Origami module for FT tracking.",
   "dependencies": {
-    "ftdomdelegate": "^4.0.0"
+    "ftdomdelegate": "^4.0.0",
+    "is-circular": "tjmehta/is-circular#^1.0.2"
   }
 }

--- a/origami.json
+++ b/origami.json
@@ -14,7 +14,11 @@
 		"required": [
 			"CustomEvent",
 			"IntersectionObserver",
-			"IntersectionObserverEntry"
+			"IntersectionObserverEntry",
+			"WeakSet",
+			"Object.entries",
+			"Object.values",
+			"Array.isArray"
 		],
 		"optional": [
 			"Promise",

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -1,5 +1,4 @@
 import utils from '../utils';
-import isCircular from 'is-circular';
 
 /**
  * Class for storing data
@@ -179,7 +178,7 @@ Store.prototype.write = function (data) {
 	if (typeof this.data === 'string') {
 		value = this.data;
 	} else {
-		if (isCircular(this.data)) {
+		if (utils.containsCircularPaths(this.data)) {
 			const errorMessage = "o-tracking does not support circular references in the analytics data.\n" +
 			"Please remove the circular references in the data.\n" +
 			"Here are the paths in the data which are circular:\n" +

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -1,4 +1,5 @@
 import utils from '../utils';
+import isCircular from 'is-circular';
 
 /**
  * Class for storing data
@@ -173,7 +174,22 @@ Store.prototype.read = function () {
 Store.prototype.write = function (data) {
 	// Set this.data, in-case we're on a file:// domain and can't set cookies.
 	this.data = data;
-	this.storage.save(this.storageKey, typeof this.data === 'string' ? this.data : JSON.stringify(this.data), this.config.expires);
+	let value;
+
+	if (typeof this.data === 'string') {
+		value = this.data;
+	} else {
+		if (isCircular(this.data)) {
+			const errorMessage = "o-tracking does not support circular references in the analytics data.\n" +
+			"Please remove the circular references in the data.\n" +
+			"Here are the paths in the data which are circular:\n" +
+			JSON.stringify(utils.findCircularPathsIn(this.data), undefined, 4);
+			throw new Error(errorMessage);
+		}
+		value = JSON.stringify(this.data);
+	}
+
+	this.storage.save(this.storageKey, value, this.config.expires);
 
 	return this;
 };

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -299,6 +299,54 @@ function findCircularPathsIn(rootObject) {
 }
 
 /**
+ * Used to find out whether an object contains a circular reference.
+ * @param {*} rootObject The object we want to search within for circular references
+ * @returns {bool} Returns true if a circular reference was found, otherwise returns false
+ */
+function containsCircularPaths(rootObject) {
+	// Used to keep track of all the values the rootObject contains
+	const traversedValues = new WeakSet();
+
+	/**
+	 *
+	 * @param {*} currentObject The current object we want to search within for circular references
+	 * @returns {true|undefined} Returns true if a circular reference was found, otherwise returns undefined
+	 */
+	function _containsCircularPaths(currentObject) {
+		// If we already saw this object
+		// the rootObject contains a circular reference
+		// and we can stop looking any further
+		if (traversedValues.has(currentObject)) {
+			return true;
+		}
+
+		// Only Objects and things which inherit from Objects can contain circular references
+		// I.E. string/number/boolean/template literals can not contain circular references
+		if (currentObject instanceof Object) {
+			traversedValues.add(currentObject);
+			// Loop through all the values of the current object and search those for circular references
+			for (const value of Object.values(currentObject)) {
+				// No need to recurse on every value because only things which inherit
+				// from Objects can contain circular references
+				if (value instanceof Object) {
+					if (_containsCircularPaths(value)) {
+						return true;
+					}
+				}
+			}
+		}
+	}
+
+	// _containsCircularPaths returns true or undefined.
+	// By using Boolean we convert the undefined into false.
+	return Boolean(
+		_containsCircularPaths(
+			rootObject
+		)
+	);
+}
+
+/**
  * Utilities.
  * @alias utils
  */
@@ -320,7 +368,8 @@ export default {
 	sanitise,
 	assignIfUndefined,
 	whitelistProps,
-	findCircularPathsIn
+	findCircularPathsIn,
+	containsCircularPaths
 };
 export {
 	log,
@@ -340,5 +389,6 @@ export {
 	sanitise,
 	assignIfUndefined,
 	whitelistProps,
-	findCircularPathsIn
+	findCircularPathsIn,
+	containsCircularPaths
 };

--- a/test/events/custom.test.js
+++ b/test/events/custom.test.js
@@ -85,4 +85,33 @@ describe('event', function () {
 
 		document.body.dispatchEvent(event);
 	});
+
+	it('should throw custom error message if the tracking event object contains circular references', function () {
+
+		const callback = sinon.spy();
+
+		const customTrackingData = {ohh: 'ahh'};
+		customTrackingData.circular = customTrackingData;
+		const errorMessage = `o-tracking does not support circular references in the analytics data.
+Please remove the circular references in the data.
+Here are the paths in the data which are circular:
+[
+    "[0].item.context.context.circular"
+]`;
+		proclaim.throws(function(){
+			trackEvent(
+				new CustomEvent("oTracking.event", {
+					detail: {
+						category: "slideshow",
+						action: "slide_viewed",
+						slide_number: 5,
+						component_id: "123456",
+						component_name: "custom-o-tracking",
+						context: customTrackingData,
+					},
+				}),
+				callback
+			);
+		}, errorMessage);
+	});
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -114,4 +114,42 @@ describe('Utils', function () {
 		});
 	});
 
+	describe('findCircularPathsIn', function() {
+		it('should return an empty array if object contains no circular references', function() {
+			proclaim.deepStrictEqual(Utils.findCircularPathsIn({ a: 1, b: 2 }), []);
+		});
+
+		it('should return an empty array if given a string literal', function() {
+			proclaim.deepStrictEqual(Utils.findCircularPathsIn(''), []);
+		});
+
+		it('should return an empty array if given a number literal', function() {
+			proclaim.deepStrictEqual(Utils.findCircularPathsIn(137), []);
+		});
+
+		it('should return an empty array if given a boolean literal', function() {
+			proclaim.deepStrictEqual(Utils.findCircularPathsIn(true), []);
+		});
+
+		it('should return an empty array if given null', function() {
+			proclaim.deepStrictEqual(Utils.findCircularPathsIn(null), []);
+		});
+
+		it('should return an array containing all the paths which are circular', function() {
+			const rootObject = {};
+			rootObject.a = rootObject;
+			rootObject.b = 2;
+			rootObject.c = '';
+			rootObject.d = null;
+			rootObject.e = true;
+			rootObject.f = [rootObject.a, 'carrot', rootObject];
+			rootObject.f.push(rootObject.f);
+			proclaim.deepStrictEqual(Utils.findCircularPathsIn(rootObject), [
+				'.a',
+				'.f[0]',
+				'.f[2]',
+				'.f[3]'
+			]);
+		});
+	});
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -152,4 +152,38 @@ describe('Utils', function () {
 			]);
 		});
 	});
+
+	describe('containsCircularPaths', function() {
+		it('should return false if object contains no circular references', function() {
+			proclaim.isFalse(Utils.containsCircularPaths({ a: 1, b: 2 }));
+		});
+
+		it('should return false if given a string literal', function() {
+			proclaim.isFalse(Utils.containsCircularPaths(''));
+		});
+
+		it('should return false if given a number literal', function() {
+			proclaim.isFalse(Utils.containsCircularPaths(137));
+		});
+
+		it('should return false if given a boolean literal', function() {
+			proclaim.isFalse(Utils.containsCircularPaths(true));
+		});
+
+		it('should return false if given null', function() {
+			proclaim.isFalse(Utils.containsCircularPaths(null));
+		});
+
+		it('should return true if given an object which contains circular references', function() {
+			const rootObject = {};
+			rootObject.a = rootObject;
+			rootObject.b = 2;
+			rootObject.c = '';
+			rootObject.d = null;
+			rootObject.e = true;
+			rootObject.f = [rootObject.a, 'carrot', rootObject];
+			rootObject.f.push(rootObject.f);
+			proclaim.isTrue(Utils.containsCircularPaths(rootObject));
+		});
+	});
 });


### PR DESCRIPTION
Resolves https://github.com/Financial-Times/o-tracking/issues/115

After speaking with the Data team and Tom Parker, we have come to the conclusion that circular objects are not going to be supported in Spoor and that o-tracking should throw an error if given a circular object