### PR TITLE
Restructure the readme to make it easier to find out how to track different items

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,12 @@
 
 Include in your product to send tracking requests to the Spoor API.
 
-- [The spoor ecosystem](#the-spoor-ecosystem)
 - [Usage](#usage)
 - [Events](#events)
 - [Parameters](#parameters)
 - [Migration Guide](#migration-guide)
 - [Contact](#contact)
 - [Licence](#licence)
-
-## The Spoor ecosystem
-![ScreenShot](https://rawgit.com/Financial-Times/o-tracking/master/resources/images/ngda-system-design.svg)
-
-[Spoor API docs](https://spoor-docs.herokuapp.com/)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ Here is the corresponding tracking pixel setup:
 
 ### Tracking with JavaScript
 
+#### Methods
+
+##### oTracking.init
+
 To manually instantiate `o-tracking`, import the component and call the `init` method with configuration which is specific to your product:
-
-If o-tracking is running on a page which has an ftsession cookie, it will automatically add that information to the data it is tracking.
-
 
 ``` js
 import oTracking from 'o-tracking';
@@ -67,6 +68,8 @@ const config = {
 };
 oTracking.init(config);
 ```
+
+##### oTracking.page
 
 To track a page view for the product you call the `oTracking.page` method.
 Page events automatically track the url and the referrer.
@@ -104,6 +107,8 @@ const pageConfig = {
 oTracking.page(pageConfig);
 ```
 
+##### oTracking.click.init
+
 Call the `oTracking.click.init` method to track click events. Pass the category you would like the click events to have as an argument:
 
 - If the element being clicked is a link which goes to a page on the same domain as the current page, o-tracking will put the tracking data into a queue to send to Spoor at a later time.
@@ -115,6 +120,8 @@ Call the `oTracking.click.init` method to track click events. Pass the category 
 const category = 'element';
 oTracking.click.init(category);
 ```
+
+##### oTracking.view.init
 
 To track when an element has come into view of the user, add the attribute `data-o-tracking-view` to the element in the page and then call the `oTracking.view.init` method:
 
@@ -147,6 +154,8 @@ const opts = {
 oTracking.view.init(opts);
 ```
 
+##### oTracking.event
+
 To track a custom event call the `oTracking.event` method:
 ```js
 const eventConfig = {
@@ -162,7 +171,7 @@ Instead of calling the `page` and `event` methods `o-tracking` can be configured
 
 ##### oTracking.page
 
-Call the `oTracking.page.init()` method to listen for `oTracking.page` events :
+Call the `oTracking.page.init()` method to listen for `oTracking.page` events:
 ```js
 // Tell o-tracking to listen for `oTracking.page` events
 oTracking.page.init();
@@ -184,51 +193,11 @@ const customData = { category: 'video', action: 'play', id: '512346789', pos: '1
 document.body.dispatchEvent(new CustomEvent('oTracking.event', { detail: customData}, bubbles: true}));
 ```
 
-### Example implementations
+## Example implementations
 
 - [ft.com](docs/ftcom_example.md)
 - [membership](docs/membership_example.md)
 
-
-Events are decorated with config values you pass in via `init()` or `updateConfig()` if they are part of `context`, `user`, or `device` objects. Values passed in as `context` to individual events will override context values from init.
-
-### Init
-```js
-{
-    server: "...",
-    context: {
-        product: "..."
-    },
-    user: {
-        ft_session: "..."
-    },
-    device: {
-        orientation: "..."
-    }
-}
-```
-
-### Updating core configuration
-```js
-{
-    device: {
-        orientation: "..."
-    }
-}
-```
-
-### Page
-```js
-{
-    url: "...",
-    referrer: "..."
-    content: {
-        uuid: "...",
-        hurdle: "..."
-    }
-    ... any other key-values ...
-}
-```
 
 ### Event
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Origami Tracking component
 
-Include in your product to send tracking requests to the Spoor API.
+Include in your product to send tracking requests to the [Spoor API](https://spoor-docs.herokuapp.com/).
 
 - [Usage](#usage)
 - [Events](#events)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Include in your product to send tracking requests to the [Spoor API](https://spo
 
 ### Tracking without JavaScript
 
-o-tracking does not work without JavaScript but, you can still send basic tracking requests to the Spoor API by setting a css background image url which points to the Spoor tracking pixel endpoint (`https://spoor-api.ft.com/px.gif`).
+o-tracking does not work without JavaScript but, you can still send basic tracking requests to the Spoor API by setting a css background image url which points to the Spoor tracking pixel endpoint (`https://spoor-api.ft.com/px.gif`). Click events and other interactive events will not be tracked without JavaScript but basic page view events can be tracked.
 
 The Spoor tracking pixel endpoint takes a `data` query parameter which is a url-encoded JSON string that represents the data to track in Spoor.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Checkout the [Origami spec](http://origami.ft.com/docs/developer-guide/using-mod
 o-tracking should have the following piece of html added, with the correct server and data filled in.
 ```html
 <div class="o-tracking o--if-no-js" data-o-component="o-tracking">
-	<div style="background:url('http://server?data={}');"></div>
+	<div style="background: url('http://server?data={}');"></div>
 </div>
 ```
 
@@ -110,9 +110,11 @@ if (cutsTheMustard) {
     <title>Full example</title>
     <!-- Add CTM styles -->
     <style type="text/css">
-        /* Hide any enhanced experience content when in core mode, and vice versa. */
-        .core .o--if-js,
-        .enhanced .o--if-no-js { display: none !important; }
+		/* Hide any enhanced experience content when in core mode, and vice versa. */
+		.core .o--if-js,
+		.enhanced .o--if-no-js {
+			display: none !important; /* stylelint-disable-line declaration-no-important */
+		}
     </style>
     <!-- Add CTM check -->
     <script>
@@ -169,7 +171,7 @@ if (cutsTheMustard) {
 <body>
 <!-- Add fallback if browsers don't cut the mustard -->
 <div class="o-tracking o--if-no-js" data-o-component="o-tracking">
-    <div style="background:url('https://spoor-api.ft.com/px.gif?data=%7B%22category%22:%22page%22,%20%22action%22:%22view%22,%20%22system%22:%7B%22apiKey%22:%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22,%22source%22:%22o-tracking%22,%22version%22:%221.0.0%22%7D,%22context%22:%7B%22product%22:%22ft.com%22,%22content%22:%7B%22asset_type%22:%22page%22%7D%7D%7D');"></div>
+    <div style="background: url('https://spoor-api.ft.com/px.gif?data=%7B%22category%22:%22page%22,%20%22action%22:%22view%22,%20%22system%22:%7B%22apiKey%22:%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22,%22source%22:%22o-tracking%22,%22version%22:%221.0.0%22%7D,%22context%22:%7B%22product%22:%22ft.com%22,%22content%22:%7B%22asset_type%22:%22page%22%7D%7D%7D');"></div>
 </div>
 <!-- Send an event -->
 <button onclick="document.body.dispatchEvent(new CustomEvent('oTracking.event', { detail: { category: 'element', action: 'click' }, bubbles: true}));">Send an event</button>

--- a/README.md
+++ b/README.md
@@ -118,7 +118,15 @@ oTracking.click.init(category);
 
 To track when an element has come into view of the user, add the attribute `data-o-tracking-view` to the element in the page and then call the `oTracking.view.init` method:
 
-* View events are fired for elements with the `data-o-tracking-view` attribute by default, unless `o-tracking`'s `selector` option is configured. Like click events, view events populate a `domPathTokens` property. To collect data for events, set the `category` option, or provide a callback[`getContextData`]
+- By default, elements with the `data-o-tracking-view` attribute are tracked.
+- To track different elements, set the `selector` option property to a CSS selector.
+- Like click events, view events will also track the path from the root of the DOM tree to the element which triggered the tracking event into a property called `domPathTokens`.
+- To categorise the view events, set the `category` option property.
+- To collect extra data to send with the tracking event, add a function named `getContextData` to the options. The function receives as it's single argument the element which triggered the tracking event and needs to return an object with any of these optional properties set:
+	- `componentContentId`
+	- `type`
+	- `subtype`
+	- `component`
 _Note:_ This feature requires `window.IntersectionObserver` in order to track the events
 _Note:_ `getContextData` should be a function which returns `{Object}`. It accepts the viewed element as an argument
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ To manually instantiate `o-tracking`, import the component and call the `init` m
 
 If o-tracking is running on a page which has an ftsession cookie, it will automatically add that information to the data it is tracking.
 
-* Automatically pickup ftsession from cookies for you.
 
 ``` js
 import oTracking from 'o-tracking';
@@ -105,10 +104,10 @@ const pageConfig = {
 oTracking.page(pageConfig);
 ```
 
-To track click events you call the `oTracking.click.init` method and pass it the category you would like the events to have:
+Call the `oTracking.click.init` method to track click events. Pass the category you would like the click events to have as an argument:
 
 - If the element being clicked is a link which goes to a page on the same domain as the current page, o-tracking will put the tracking data into a queue to send to Spoor at a later time.
-- If you want to send the data to Spoor immediately, you can add the attribute `data-o-tracking-skip-queue` onto the element.
+- Add the attribute `data-o-tracking-skip-queue` to the element to send the data to Spoor immediately.
 - O-tracking click events will also track the path from the root of the DOM tree to the element which was clicked. This is recorded in a property called `domPathTokens`.
 - If the clicked element has the `data-trackable` attribute set, sibling elements will also be included within the `domPathTokens` property.
 ```js
@@ -140,7 +139,7 @@ const opts = {
 oTracking.view.init(opts);
 ```
 
-To track a custom event you call the `oTracking.event` method:
+To track a custom event call the `oTracking.event` method:
 ```js
 const eventConfig = {
     "category": "video",
@@ -151,11 +150,11 @@ oTracking.event(eventConfig);
 
 #### Events
 
-You can configure o-tracking to listen for `oTracking.page` and `oTracking.event` events instead of using the `page` and `event` methods.
+Instead of calling the `page` and `event` methods `o-tracking` can be configured to fire events based on the custom DOM Events `oTracking.page` and `oTracking.event`.
 
 ##### oTracking.page
 
-To make o-tracking listen for `oTracking.page` events, you call `oTracking.page.init()`:
+Call the `oTracking.page.init()` method to listen for `oTracking.page` events :
 ```js
 // Tell o-tracking to listen for `oTracking.page` events
 oTracking.page.init();

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ oTracking.init(config);
 
 To track a page view for the product you call the `oTracking.page` method.
 Page events automatically track the url and the referrer.
+Please refer to the [event document](docs/event.md) for information about all the possible properties which can be set.
 ```js
 const pageConfig = {
   content: {
@@ -115,6 +116,8 @@ Call the `oTracking.click.init` method to track click events. Pass the category 
 - Add the attribute `data-o-tracking-skip-queue` to the element to send the data to Spoor immediately.
 - O-tracking click events will also track the path from the root of the DOM tree to the element which was clicked. This is recorded in a property called `domPathTokens`.
 - If the clicked element has the `data-trackable` attribute set, sibling elements will also be included within the `domPathTokens` property.
+
+Please refer to the [event document](docs/event.md) for information about all the possible properties which can be set.
 ```js
 // Tracking a click
 const category = 'element';
@@ -136,6 +139,8 @@ To track when an element has come into view of the user, add the attribute `data
 	- `component`
 _Note:_ This feature requires `window.IntersectionObserver` in order to track the events
 _Note:_ `getContextData` should be a function which returns `{Object}`. It accepts the viewed element as an argument
+
+Please refer to the [event document](docs/event.md) for information about all the possible properties which can be set.
 
 ```js
 const opts = {
@@ -164,6 +169,8 @@ const eventConfig = {
 };
 oTracking.event(eventConfig);
 ```
+Please refer to the [event document](docs/event.md) for information about all the possible properties which can be set.
+
 
 #### Events
 
@@ -197,34 +204,6 @@ document.body.dispatchEvent(new CustomEvent('oTracking.event', { detail: customD
 
 - [ft.com](docs/ftcom_example.md)
 - [membership](docs/membership_example.md)
-
-
-### Event
-
-__Important__: To decide how to name the category and action fields, consider this sentence (square brackets denote that part is optional):
-
-#### A user can {action} a {category}[ with/having a {context}[ to {destination}]]
-
-For example:
-* A user can view a page having a uuid.
-* A user can play a video having a video ID.
-* A user can share a comment having a comment ID to Facebook.
-* A user can share an article having a uuid to email.
-* A user can scroll a page with a asset type.
-* A user can open an email.
-* A user can click an element.
-
-```js
-{
-    category: 'video',
-    action: 'play',
-    ... any other key-values ...
-    id: '512346789',
-    pos: '10'
-}
-```
-
-[Look at all the properties](docs/event.md) available for an event.
 
 
 ## Migration Guide

--- a/README.md
+++ b/README.md
@@ -49,64 +49,132 @@ Here is the corresponding tracking pixel setup:
 </div>
 ```
 
-### Recommended implementation using the build service
+### Tracking with JavaScript
 
-Use an onload handler to check when o-tracking has loaded and then init.
+To manually instantiate `o-tracking`, import the component and call the `init` method with configuration which is specific to your product:
 
-```js
-// CTM
-if (cutsTheMustard) {
-    var o = document.createElement('script');
-    o.async = o.defer = true;
-    o.src = 'https://build.origami.ft.com/v2/bundles/js?modules=o-tracking';
-    var s = document.getElementsByTagName('script')[0];
-    if (o.hasOwnProperty('onreadystatechange')) {
-        o.onreadystatechange = function() {
-            if (o.readyState === "loaded") {
-                oTrackinginit();
-            }
-        };
-    } else {
-        o.onload = oTrackinginit;
-    }
-    s.parentNode.insertBefore(o, s);
-}
-```
+If o-tracking is running on a page which has an ftsession cookie, it will automatically add that information to the data it is tracking.
 
-The `oTrackinginit` function, used above, would have function calls to setup o-tracking and likely send a page view event. e.g.
+* Automatically pickup ftsession from cookies for you.
 
-```js
-function oTrackinginit() {
-    var oTracking = Origami['o-tracking'];
-    // Setup
-    oTracking.init({...config...});
-    // Page
-    oTracking.page({...config...});
-    // Clicks.
-    oTracking.click.init(category);
-    // Components/Elements views.
-    oTracking.view.init({...opts...});
-}
-```
-
-### Alternative implementation using require
-
-Use the build service or require locally to load o-tracking and init manually.
-```js
+``` js
 import oTracking from 'o-tracking';
+
+const config = {
+    context: {
+        // This value is used as a way to identify the high-level product, for example: ft.com, FT app, biz-ops etc.
+        product: 'o-tracking-example',
+    }
+};
+oTracking.init(config);
 ```
 
+To track a page view for the product you call the `oTracking.page` method.
+Page events automatically track the url and the referrer.
 ```js
-if (cutsTheMustard) {
-    // Setup
-    oTracking.init({...config...});
-    // Page
-    oTracking.page({...config...});
-    // Clicks
-    oTracking.click.init(category);
-    // Components/Elements views.
-    oTracking.view.init({...opts...});
-}
+const pageConfig = {
+  content: {
+      /*
+        Asset type is meant to describe the main purpose of the page
+        The value can be one of these:
+        - `story` - A story or article
+        - `blog` - A blog post
+        - `front` - A home page or front page
+        - `ad` - An advert.
+        - `image` - An image
+        - `interactive` - An interactive graphic
+        - `report` - A special report
+        - `search` - A search results page
+        - `section` - A section or listing page
+        - `topic` -  A topic landing page
+        - `video` - A video page
+        - `login` - Any login/sign-in page
+        - `stream` - A stream page
+        - `funnel` - Any funnel page
+        - `epaper` - all epaper pages
+        - `rankings` - A rankings page for schools and courses (i.e. on rankings.ft.com). Not the section's hub page
+        - `markets` - Any market, bond, commoditity, stock, currency 'tearsheet' (usually has "/tearsheet/" in URL)
+        - `myft` - All MyFT pages
+        - `account` - All account pages
+        - `membership` - All membership pages
+        - `page` - anything else, not above.
+    */
+    asset_type: "story"
+  }
+};
+oTracking.page(pageConfig);
+```
+
+To track click events you call the `oTracking.click.init` method and pass it the category you would like the events to have:
+
+- If the element being clicked is a link which goes to a page on the same domain as the current page, o-tracking will put the tracking data into a queue to send to Spoor at a later time.
+- If you want to send the data to Spoor immediately, you can add the attribute `data-o-tracking-skip-queue` onto the element.
+- O-tracking click events will also track the path from the root of the DOM tree to the element which was clicked. This is recorded in a property called `domPathTokens`.
+- If the clicked element has the `data-trackable` attribute set, sibling elements will also be included within the `domPathTokens` property.
+```js
+// Tracking a click
+const category = 'element';
+oTracking.click.init(category);
+```
+
+To track when an element has come into view of the user, add the attribute `data-o-tracking-view` to the element in the page and then call the `oTracking.view.init` method:
+
+* View events are fired for elements with the `data-o-tracking-view` attribute by default, unless `o-tracking`'s `selector` option is configured. Like click events, view events populate a `domPathTokens` property. To collect data for events, set the `category` option, or provide a callback[`getContextData`]
+_Note:_ This feature requires `window.IntersectionObserver` in order to track the events
+_Note:_ `getContextData` should be a function which returns `{Object}`. It accepts the viewed element as an argument
+
+```js
+const opts = {
+    category: 'audio', // default: 'component'
+    selector: '.o-teaser__audio', // default: '[data-o-tracking-view]'
+    getContextData: (el) => {  // default: null
+        return {
+            componentContentId: el.getAttribute('data-id'),
+            type: 'audio',
+            subtype: 'podcast',
+            component: 'teaser'
+        };
+    }
+};
+
+oTracking.view.init(opts);
+```
+
+To track a custom event you call the `oTracking.event` method:
+```js
+const eventConfig = {
+    "category": "video",
+    "action": "play",
+};
+oTracking.event(eventConfig);
+```
+
+#### Events
+
+You can configure o-tracking to listen for `oTracking.page` and `oTracking.event` events instead of using the `page` and `event` methods.
+
+##### oTracking.page
+
+To make o-tracking listen for `oTracking.page` events, you call `oTracking.page.init()`:
+```js
+// Tell o-tracking to listen for `oTracking.page` events
+oTracking.page.init();
+
+// Now we can send page events and o-tracking will track the data within them.
+const pageData = { content: { uuid: 'abc-123', barrier: 'PREMIUM' };
+document.body.dispatchEvent(new CustomEvent('oTracking.page', { detail: pageData}, bubbles: true}));
+```
+
+##### oTracking.event
+
+To make o-tracking listen for `oTracking.event` events, you call `oTracking.event.init()`:
+```js
+// Tell o-tracking to listen for `oTracking.event` events
+oTracking.event.init();
+
+// Now we can send custom events and o-tracking will track the data within them.
+const customData = { category: 'video', action: 'play', id: '512346789', pos: '10' };
+document.body.dispatchEvent(new CustomEvent('oTracking.event', { detail: customData}, bubbles: true}));
 ```
 
 ### Example implementations
@@ -114,128 +182,6 @@ if (cutsTheMustard) {
 - [ft.com](docs/ftcom_example.md)
 - [membership](docs/membership_example.md)
 
-#### Full example
-```html
-<!DOCTYPE html>
-<!-- Add core class to head tag -->
-<head class="core">
-<head>
-    <title>Full example</title>
-    <!-- Add CTM styles -->
-    <style type="text/css">
-		/* Hide any enhanced experience content when in core mode, and vice versa. */
-		.core .o--if-js,
-		.enhanced .o--if-no-js {
-			display: none !important; /* stylelint-disable-line declaration-no-important */
-		}
-    </style>
-    <!-- Add CTM check -->
-    <script>
-        var cutsTheMustard = ('querySelector' in document && 'localStorage' in window && 'addEventListener' in window);
-        if (cutsTheMustard) {
-        // Swap the 'core' class on the HTML element for an 'enhanced' one
-        // We're doing it early in the head to avoid a flash of unstyled content
-        document.documentElement.className = document.documentElement.className.replace(/\bcore\b/g, 'enhanced');
-        }
-    </script>
-    <!-- Add Polyfil service -->
-    <script src="https://cdn.polyfill.io/v1/polyfill.min.js"></script>
-    <!-- INIT and make a page request -->
-    <script>
-        function oTrackinginit() {
-            // oTracking
-            var oTracking = Origami['o-tracking'];
-            var config_data = {
-                server: 'https://spoor-api.ft.com/px.gif',
-                context: {
-                    product: 'ft.com'
-                },
-                user: {
-                    ft_session: oTracking.utils.getValueFromCookie(/FTSession=([^;]+)/)
-                }
-            }
-            // Setup
-            oTracking.init(config_data);
-            // Page
-            oTracking.page({
-                content: {
-                    asset_type: 'page'
-                }
-            });
-        }
-        if (cutsTheMustard) {
-            var o = document.createElement('script');
-            o.async = o.defer = true;
-            o.src = 'https://build.origami.ft.com/v2/bundles/js?modules=o-tracking';
-            var s = document.getElementsByTagName('script')[0];
-            if (o.hasOwnProperty('onreadystatechange')) {
-                o.onreadystatechange = function() {
-                    if (o.readyState === "loaded") {
-                        oTrackinginit();
-                    }
-                };
-            } else {
-                o.onload = oTrackinginit;
-            }
-            s.parentNode.insertBefore(o, s);
-        }
-    </script>
-</head>
-<body>
-<!-- Add fallback if browsers don't cut the mustard -->
-<div class="o-tracking o--if-no-js" data-o-component="o-tracking">
-    <div style="background: url('https://spoor-api.ft.com/px.gif?data=%7B%22category%22:%22page%22,%20%22action%22:%22view%22,%20%22system%22:%7B%22apiKey%22:%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22,%22source%22:%22o-tracking%22,%22version%22:%221.0.0%22%7D,%22context%22:%7B%22product%22:%22ft.com%22,%22content%22:%7B%22asset_type%22:%22page%22%7D%7D%7D');"></div>
-</div>
-<!-- Send an event -->
-<button onclick="document.body.dispatchEvent(new CustomEvent('oTracking.event', { detail: { category: 'element', action: 'click' }, bubbles: true}));">Send an event</button>
-</body>
-</html>
-```
-
-## Events
-
-`o-tracking` captures events automatically when initialised with the methods [outlined above](#useage). In addition, `o-tracking` will capture custom `oTracking.page` and `oTracking.event` events:
-
-- `oTracking.page`
-
-    Send a page view event
-
-    ```js
-    document.body.dispatchEvent(new CustomEvent('oTracking.page', { detail: { content: { uuid: 'abc-123', barrier: 'PREMIUM' }}, bubbles: true}));
-    ```
-- `oTracking.event`
-
-    Send a normal event
-
-    ```js
-    document.body.dispatchEvent(new CustomEvent('oTracking.event', { detail: { category: 'video', action: 'play', id: '512346789', pos: '10' }, bubbles: true}));
-    ```
-
-## Parameters
-
-o-tracking will
-* Automatically pickup ftsession from cookies for you.
-* Page events automatically pick up the url and the referrer.
-* Click events [initalised as above](#usage), will populate a `domPathTokens` property. If the clicked element has the `data-trackable` attribute, sibling elements will also be included within `domPathTokens`.
-* View events are fired for elements with the `data-o-tracking-view` attribute by default, unless `o-tracking`'s `selector` option is configured. Like click events, view events populate a `domPathTokens` property. To collect data for events, set the `category` option, or provide a callback[`getContextData`]
-_Note:_ This feature requires `window.IntersectionObserver` in order to track the events
-_Note:_ `getContextData` should be a function which returns `{Object}`. It accepts the viewed element as an argument
-	```js
-	const opts = {
-		category: 'audio', // default: 'component'
-		selector: '.o-teaser__audio', // default: '[data-o-tracking-view]'
-		getContextData: (el) => {  // default: null
-			return {
-				componentContentId: el.getAttribute('data-id'),
-				type: 'audio',
-				subtype: 'podcast',
-			 	component: 'teaser'
-			};
-		}
-	}
-
-	oTracking.view.init(opts);
-	```
 
 Events are decorated with config values you pass in via `init()` or `updateConfig()` if they are part of `context`, `user`, or `device` objects. Values passed in as `context` to individual events will override context values from init.
 
@@ -303,8 +249,6 @@ For example:
 ```
 
 [Look at all the properties](docs/event.md) available for an event.
-
-[JSDoc](https://registry.origami.ft.com/components/o-tracking/jsdoc#Tracking)
 
 
 ## Migration Guide

--- a/README.md
+++ b/README.md
@@ -11,22 +11,41 @@ Include in your product to send tracking requests to the [Spoor API](https://spo
 
 ## Usage
 
-### Requirement: Polyfills & Doesn't cut the mustard
-_Applies to both quickstart examples below_
+### Tracking without JavaScript
 
+o-tracking does not work without JavaScript but, you can still send basic tracking requests to the Spoor API by setting a css background image url which points to the Spoor tracking pixel endpoint (`https://spoor-api.ft.com/px.gif`).
 
-Add the [polyfill](https://cdn.polyfill.io/) service to your site to make sure o-tracking runs in as many browsers as possible.
+The Spoor tracking pixel endpoint takes a `data` query parameter which is a url-encoded JSON string that represents the data to track in Spoor.
 
-Require the noscript version of o-tracking incase the browser doesn't cut the mustard.
-
-Checkout the [Origami spec](http://origami.ft.com/docs/developer-guide/using-modules/#core-vs-enhanced-experience) for the correct CTM logic, [html and css changes](http://origami.ft.com/docs/developer-guide/using-modules/#styles-for-fallbacks-and-enhancements) needed.
-
-
-
-o-tracking should have the following piece of html added, with the correct server and data filled in.
 ```html
 <div class="o-tracking o--if-no-js" data-o-component="o-tracking">
-	<div style="background: url('http://server?data={}');"></div>
+	<div style="background: url('https://spoor-api.ft.com/px.gif?data=YOUR_URL_ENCODED_JSON_DATA_HERE');"></div>
+</div>
+```
+
+For example, if you have the following data you want to track in Spoor:
+
+```json
+{
+  "category": "page",
+  "action": "view",
+  "system": {
+    "apiKey": "qUb9maKfKbtpRsdp0p2J7uWxRPGJEP",
+    "source": "o-tracking",
+    "version": "1.0.0"
+  },
+  "context": {
+    "product": "ft.com",
+    "content": {
+      "asset_type": "page"
+    }
+  }
+}
+```
+Here is the corresponding tracking pixel setup:
+```html
+<div class="o-tracking o--if-no-js" data-o-component="o-tracking">
+    <div style="background: url('https://spoor-api.ft.com/px.gif?data=%7B%22category%22:%22page%22,%20%22action%22:%22view%22,%20%22system%22:%7B%22apiKey%22:%22qUb9maKfKbtpRsdp0p2J7uWxRPGJEP%22,%22source%22:%22o-tracking%22,%22version%22:%221.0.0%22%7D,%22context%22:%7B%22product%22:%22ft.com%22,%22content%22:%7B%22asset_type%22:%22page%22%7D%7D%7D');"></div>
 </div>
 ```
 

--- a/docs/event.md
+++ b/docs/event.md
@@ -6,6 +6,29 @@
 
 This allows a low barrier to entry for anyone wanting to submit events to Spoor.
 
+__Important__: To decide how to name the category and action fields, consider this sentence (square brackets denote that part is optional):
+
+*A user can {action} a {category}[ with/having a {context}[ to {destination}]]*
+
+For example:
+* A user can view a page having a uuid.
+* A user can play a video having a video ID.
+* A user can share a comment having a comment ID to Facebook.
+* A user can share an article having a uuid to email.
+* A user can scroll a page with a asset type.
+* A user can open an email.
+* A user can click an element.
+
+```js
+{
+    category: 'video',
+    action: 'play',
+    ... any other key-values ...
+    id: '512346789',
+    pos: '10'
+}
+```
+
 ## Format
 
 ```
@@ -15,7 +38,6 @@ This allows a low barrier to entry for anyone wanting to submit events to Spoor.
 	"system": {
 		"source": "o-tracking",									// Name of the sender's system [1]
 		"version": "1.0.0",										// Source semver
-		"api_key":	"0f7464b4-3f4d-11e4-984b-00144feabdc0"		// Sender-specific key [6]
 	},
 	"device": {
 		"spoor_id": "0f7464b4-3f4d-11e4-984b-00144feabdc0",		// Unique ID for this device
@@ -73,6 +95,7 @@ This allows a low barrier to entry for anyone wanting to submit events to Spoor.
 - It is intentionally abstracted away from any particular database format and meant to represent a logical, easy to understand data structure.
 - It assumes the consumers of the event stream can manipulate the data in to their desired storage format.
 - It doesn't assume users of the data will need to join the data across tables to find the information they want.
+
 
 ## References
 1.  The general convention might be something like `product.sub-system.environment` - Eg, 'webapp.render.uat'

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"eslint-config-origami-component": "^2.0.1",
 		"origami-build-tools": "^10.1.9",
 		"origami-ci-tools": "^2.0.1",
+		"remark-preset-lint-origami-component": "^1.1.1",
 		"stylelint-config-origami-component": "^1.0.3"
 	},
 	"repository": {


### PR DESCRIPTION
I've replaced the "doesn't cut the mustard" section with a section titled "Tracking without JavaScript" as I think not everyone know what "cutting the mustard" means.

I've also added a section named "Tracking with JavaScript", which is where we can document all the o-tracking methods.

I also replaced the embedded full HTML example with a link to the example as a separate file to cut down on the readme size.