### PR TITLE
Remove documentation about deprecated user.erights_id tracking data

### DIFF
--- a/docs/enrichment.md
+++ b/docs/enrichment.md
@@ -32,7 +32,6 @@
 		"ft_session": "asdf324dfag1ds%asdf1A-1sadsadf",		// FT Session token
 		"ft_guid": "0f7464b4-3f4d-11e4-984b-00144feabdc0",	// FT User GUID
 		"passport_id": "1234556789",							// Passport ID - soon to be deprecated
-		"erights_id": "12345567",								// eRights ID - soon to be deprecated
 		"isStaff": true,
 		"ab": {
             "test_name": "variant"								// [9]

--- a/docs/event.md
+++ b/docs/event.md
@@ -56,7 +56,6 @@ For example:
 		"ft_session": "asdf324dfag1ds%asdf1A-1sadsadf",			// FT Session token
 		"ft_guid": "0f7464b4-3f4d-11e4-984b-00144feabdc0",		// FT User GUID
 		"passport_id": "1234556789",							// Passport ID - soon to be deprecated
-		"erights_id": "12345567"								// eRights ID - soon to be deprecated
 	},
 	"time": {
 		 "offset": 234											// Lag between event being created and sent (milliseconds) e.g. if offline.


### PR DESCRIPTION
erights_id is not generated internally by o-tracking and is not used in Spoor at all. The only reference left in o-tracking is these two documentation files