### PR TITLE
Remove tracking.prototype.utils from the public API

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,11 +3,7 @@
 
 ## Migrating from v2 to v3
 
-The method `whitelistProps` has been renamed to `filterProperties`.
-```diff
--Tracking.prototype.utils.whitelistProps
-+Tracking.prototype.utils.filterProperties
-```
+The `Tracking.prototype.utils` object has been removed.
 
 The methods `setDomain` and `getDomain` have been removed, o-tracking only works with the spoor domain, which is set automatically.
 

--- a/docs/membership_example.md
+++ b/docs/membership_example.md
@@ -32,11 +32,6 @@
                 server: 'https://spoor-api.ft.com/px.gif',
                 context: {
                     product: 'ft.com'
-                },
-                user: {
-                    passport_id: otracking.utils.getValueFromCookie(/USERID=([0-9]+):/) || otracking.utils.getValueFromCookie(/PID=([0-9]+)\_/),
-                    ft_session: otracking.utils.getValueFromCookie(/FTSession=([^;]+)/),
-                    ft_session_s: otracking.utils.getValueFromCookie(/FTSession_s=([^;]+)/)
                 }
             }
             // oTracking

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -5,8 +5,8 @@ import send from './core/send';
 import event from './events/custom';
 import page from './events/page-view';
 import click from './events/click';
-import utils from './utils';
 import core from './core';
+import utils from './utils';
 import componentView from './events/component-view';
 
 /**
@@ -89,12 +89,6 @@ Tracking.prototype.view = componentView;
  * @see {@link click#init}
  */
 Tracking.prototype.click = click;
-
-/**
- * Tracking utilities.
- * @see {@link utils}
- */
-Tracking.prototype.utils = utils;
 
 /**
  * Get the rootID.
@@ -180,7 +174,7 @@ Tracking.prototype.init = function(config) {
 Tracking.prototype.updateConfig = function(newConfig) {
 	let config = settings.get('config') || {};
 
-	config = this.utils.merge(config, newConfig);
+	config = utils.merge(config, newConfig);
 	settings.set('config', config);
 
 	// Developer mode
@@ -229,7 +223,7 @@ Tracking.prototype._getDeclarativeConfig = function(options) {
 		declarativeOptions = JSON.parse(declarativeConfigString);
 	} catch(e) {
 		const configError = new Error('Invalid JSON configuration syntax, check validity for o-tracking configuration: "' + e.message + '"');
-		this.utils.broadcast('oErrors', 'log', {
+		utils.broadcast('oErrors', 'log', {
 			error: configError.message,
 			info: { module: 'o-tracking' }
 		});


### PR DESCRIPTION
These utils are not required for use outside of o-tracking's codebase