### PR TITLE
Improve/fix the JSDoc types being declared across the codebase

### DIFF
--- a/src/javascript/core.js
+++ b/src/javascript/core.js
@@ -33,22 +33,17 @@ function getRootID() {
  * Make a tracking request.
  *
  * @param {Object} config - Should be passed an object containing a format and the values for that format
- * @param {function} callback - Fired when the request has been made.
+ * @param {function=} callback - Fired when the request has been made.
  *
  * @return {Object} request
  */
-function track(config, callback) {
-	if (utils.isUndefined(callback)) {
-		// eslint-disable-next-line no-empty-function
-		callback = function () {};
-	}
+function track(config, callback = function(){ /* empty */}) {
 	const session = Session.session();
 
 	// Set up the base request object with some values which should always be sent.
 	const request = {
 		async: true,
-		// eslint-disable-next-line no-empty-function
-		callback: callback || function() {},
+		callback,
 		context: {
 			id: config.id || utils.guid(), // Use a supplied id or generate one for this request
 			root_id: getRootID(),

--- a/src/javascript/core.js
+++ b/src/javascript/core.js
@@ -49,7 +49,7 @@ function track(config, callback = function(){ /* empty */}) {
 			root_id: getRootID(),
 		},
 		user: {
-			passport_id: utils.getValueFromCookie(/USERID=([0-9]+):/) || utils.getValueFromCookie(/PID=([0-9]+)\_/),
+			passport_id: utils.getValueFromCookie(/USERID=([0-9]+):/) || utils.getValueFromCookie(/PID=([0-9]+)_/),
 			ft_session: utils.getValueFromCookie(/FTSession=([^;]+)/),
 			ft_session_s: utils.getValueFromCookie(/FTSession_s=([^;]+)/)
 		},

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -128,15 +128,10 @@ function add(request) {
 /**
  * If there are any requests queued, attempts to send the next one
  * Otherwise, does nothing
- * @param {Function} callback - Optional callback
+ * @param {Function=} callback - Optional callback
  * @return {void}
  */
-function run(callback) {
-	if (utils.isUndefined(callback)) {
-		// eslint-disable-next-line no-empty-function
-		callback = function () {};
-	}
-
+function run(callback = function () { /* empty */}) {
 	// Investigate queue lengths bug
 	// https://jira.ft.com/browse/DTP-330
 	const all_events = queue.all();

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -26,7 +26,7 @@ function should_use_sendBeacon() {
  *
  * @param {Object} request The request to be sent.
  * @param {Function} callback Callback to fire the next item in the queue.
- * @return {undefined}
+ * @return {void}
  */
 function sendRequest(request, callback) {
 	const queueTime = request.queueTime;
@@ -113,7 +113,7 @@ function sendRequest(request, callback) {
  * Adds a new request to the list of pending requests
  *
  * @param {Tracking} request The request to queue
- * @return {undefined}
+ * @return {void}
  */
 function add(request) {
 	request.queueTime = new Date().getTime();
@@ -129,7 +129,7 @@ function add(request) {
  * If there are any requests queued, attempts to send the next one
  * Otherwise, does nothing
  * @param {Function} callback - Optional callback
- * @return {undefined}
+ * @return {void}
  */
 function run(callback) {
 	if (utils.isUndefined(callback)) {
@@ -187,7 +187,7 @@ function run(callback) {
  * Convenience function to add and run a request all in one go.
  *
  * @param {Object} request The request to queue and run.
- * @return {undefined}
+ * @return {void}
  */
 function addAndRun(request) {
 	add(request);

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -25,7 +25,7 @@ function should_use_sendBeacon() {
  * Attempts to send a tracking request.
  *
  * @param {Object} request The request to be sent.
- * @param {Function} callback Callback to fire the next item in the queue.
+ * @param {Function=} callback Callback to fire the next item in the queue.
  * @return {void}
  */
 function sendRequest(request, callback) {

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -155,7 +155,7 @@ function run(callback = function () { /* empty */}) {
 			category: 'o-tracking',
 			action: 'queue-bug',
 			context: {
-				url: document.url,
+				url: document.URL,
 				queue_length: all_events.length,
 				counts: counts,
 				storage: queue.storage.storage._type

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -112,7 +112,7 @@ function sendRequest(request, callback) {
 /**
  * Adds a new request to the list of pending requests
  *
- * @param {Tracking} request The request to queue
+ * @param {Object} request The request to queue
  * @return {void}
  */
 function add(request) {

--- a/src/javascript/core/session.js
+++ b/src/javascript/core/session.js
@@ -12,7 +12,7 @@ const defaultSessionConfig = {
  * Set the session in the store.
  *
  * @param {String} session - The session to be stored.
- * @return {undefined}
+ * @return {void}
  */
 function setSession(session) {
 	const d = new Date();

--- a/src/javascript/core/session.js
+++ b/src/javascript/core/session.js
@@ -1,6 +1,12 @@
 import utils from '../utils';
 import Store from './store';
 
+/**
+ * @typedef {Object} Session
+ * @property {string} id - The id of the session
+ * @property {boolean} isNew - Whether it is a brand new session
+ */
+
 let store;
 const defaultSessionConfig = {
 	storage: 'best',
@@ -27,7 +33,7 @@ function setSession(session) {
 /**
  * Get the session from the store. Expiry and gen of a new session are handled here.
  *
- * @return {Object} the current session
+ * @return {Session} the current session
  */
 function getSession() {
 	const s = store.read();

--- a/src/javascript/core/settings.js
+++ b/src/javascript/core/settings.js
@@ -27,7 +27,7 @@ function clone(value) {
  *
  * @param {string} key - The key to use to store the object
  * @param {*} value - The value
- * @return {undefined}
+ * @return {void}
  */
 function setValue(key, value) {
 	settings[key] = clone(value);
@@ -48,7 +48,7 @@ function getValue(key) {
  * Deletes a value
  *
  * @param  {string} key - The key to delete
- * @return {undefined}
+ * @return {void}
  */
 function destroy(key) {
 	delete settings[key];

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -6,7 +6,7 @@ import utils from '../utils';
  *
  * @class  Store
  * @param {string} name - The name of the store
- * @param {Object} config - Optional, config object for extra configuration
+ * @param {Object=} config - Optional, config object for extra configuration
  */
 const Store = function (name, config) {
 

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -99,7 +99,7 @@ const Store = function (name, config) {
 			if (utils.is(expiry, 'number')) {
 				d = new Date();
 				d.setTime(d.getTime() + expiry);
-				expires = 'expires=' + d.toGMTString() + ';';
+				expires = 'expires=' + d.toUTCString() + ';';
 			}
 
 			const cookie = utils.encode(name) + '=' + utils.encode(value) + ';' + expires + 'path=/;' + (config.domain ? 'domain=.' + config.domain + ';' : '');

--- a/src/javascript/events/click.js
+++ b/src/javascript/events/click.js
@@ -72,7 +72,7 @@ const handleClickEvent = eventData => (clickEvent, clickElement) => {
 /**
  * If there are any requests queued, attempts to send the next one
  * Otherwise, does nothing
- * @return {undefined}
+ * @return {void}
  */
 /*eslint-disable no-unused-vars*/
 const runQueue = _ => {
@@ -90,7 +90,7 @@ const runQueue = _ => {
  * @alias click#init
  * @param {String} category - The event category for clicks.
  * @param {String} elementsToTrack - A query selector string to select elements to track links on {@link https://github.com/ftlabs/ftdomdelegate#selector-string}.
- * @return {undefined}
+ * @return {void}
  */
 const init = (category, elementsToTrack) => {
 	elementsToTrack = elementsToTrack || 'a, button, input, [role="button"]'; // See https://github.com/ftlabs/ftdomdelegate#selector-string

--- a/src/javascript/events/click.js
+++ b/src/javascript/events/click.js
@@ -7,13 +7,6 @@ import getTrace from '../../libs/get-trace';
 
 let internalQueue;
 
-const eventPropertiesToCollect = [
-	"ctrlKey",
-	"altKey",
-	"shiftKey",
-	"metaKey",
-];
-
 // Trigger the event tracking
 const track = eventData => {
 	const firstDomPathToken = eventData.context.domPathTokens[0];
@@ -35,19 +28,28 @@ const track = eventData => {
 	}
 };
 
+const eventPropertiesToCollect = [
+	"ctrlKey",
+	"altKey",
+	"shiftKey",
+	"metaKey",
+];
+
 // Get properties for the event (as opposed to properties of the clicked element)
 // Available properties include mouse x- and y co-ordinates, for example.
 const getEventProperties = event => {
-	const eventProperties = eventPropertiesToCollect.reduce((returnObject, property) => {
-		try {
-			if (event[property]) {returnObject[property] = utils.sanitise(event[property]);}
+	const eventProperties = {};
+	for (const property of eventPropertiesToCollect) {
+		if (event[property]) {
+			try {
+				eventProperties[property] = utils.sanitise(event[property]);
+			} catch (e) {
+				// eslint-disable-next-line no-console
+				console.log(e);
+			}
 		}
-		catch (e) {
-			// eslint-disable-next-line no-console
-			console.log(e);
-		}
-		return returnObject;
-	}, {});
+	}
+
 	return eventProperties;
 };
 

--- a/src/javascript/events/custom.js
+++ b/src/javascript/events/custom.js
@@ -24,7 +24,7 @@ const defaultEventConfig = function () {
  *   [component_id] - Optional. The ID for the component instance.
  *
  * @param {Function} callback - Optional, Callback function. Called when request completed.
- * @return {undefined}
+ * @return {void}
  */
 function event(trackingEvent, callback) {
 	if (utils.is(trackingEvent.detail.category) || utils.is(trackingEvent.detail.action)) {

--- a/src/javascript/events/custom.js
+++ b/src/javascript/events/custom.js
@@ -2,6 +2,18 @@ import Core from '../core';
 import utils from '../utils';
 
 /**
+ * @typedef {Object} TrackingEvent
+ * @property {EventDetail} detail - The custom o-tracking event details
+ *
+ * @typedef {Event & TrackingEvent} OTrackingEvent
+ *
+ * @typedef {Object} EventDetail
+ * @property {number} category - Category for this event e.g. page
+ * @property {number} action - Action for this event e.g. view
+ * @property {Object} context - Extra context to add to the event
+ */
+
+/**
  * Default properties for events.
  *
  * @type {Object}
@@ -18,7 +30,7 @@ const defaultEventConfig = function () {
 /**
  * Track an event.
  *
- * @param {Event} trackingEvent - The event, which could the following properties in its 'detail' key:
+ * @param {OTrackingEvent} trackingEvent - The event, which could the following properties in its 'detail' key:
  *   [category] - The category, for example: video
  *   [action] - The action performed, for example: play
  *   [component_id] - Optional. The ID for the component instance.

--- a/src/javascript/events/custom.js
+++ b/src/javascript/events/custom.js
@@ -74,7 +74,7 @@ function getOrigamiEventTarget(event) {
  *
  * @param {HTMLElement} element - The HTML Element to gen an ID for.
  *
- * @return {string} hash
+ * @return {number} hash
  */
 function getComponentId(element) {
 	const path = _getElementPath(element);

--- a/src/javascript/events/page-view.js
+++ b/src/javascript/events/page-view.js
@@ -27,7 +27,7 @@ const defaultPageConfig = function () {
  *
  * @param {Object} config - Configuration object. If omitted, will use the defaults.
  * @param {Function} callback - Callback function. Called when request completed.
- * @return {undefined}
+ * @return {void}
  */
 function page(config, callback) {
 	config = utils.merge(defaultPageConfig(), {
@@ -51,7 +51,7 @@ function page(config, callback) {
  *
  * @param {CustomEvent} e - The CustomEvent
  * @private
- * @return {undefined}
+ * @return {void}
  */
 function listener(e) {
 	page(e.detail);

--- a/src/javascript/events/page-view.js
+++ b/src/javascript/events/page-view.js
@@ -26,7 +26,7 @@ const defaultPageConfig = function () {
  * Make the page tracking request.
  *
  * @param {Object} config - Configuration object. If omitted, will use the defaults.
- * @param {Function} callback - Callback function. Called when request completed.
+ * @param {Function=} callback - Callback function. Called when request completed.
  * @return {void}
  */
 function page(config, callback) {

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -41,8 +41,8 @@ Tracking.prototype.developer = function(level) {
 	if (level) {
 		settings.set('developer', true);
 	} else {
-		settings.destroy('developer', null);
-		settings.destroy('no_send', null);
+		settings.destroy('developer');
+		settings.destroy('no_send');
 	}
 };
 

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -121,10 +121,11 @@ Tracking.prototype.getRootID = core.getRootID;
  * </script>
  *
  * @param {Object} config 					- See {@link Tracking} for the configuration options.
- * @param {boolean} config.developer        - Optional, if `true`, logs certain actions.
- * @param {boolean} config.noSend           - Optional, if `true`, won't send events.
- * @param {string} config.configId          - Optional
- * @param {string} config.session           - Optional
+ * @param {boolean=} config.developer        - Optional, if `true`, logs certain actions.
+ * @param {boolean=} config.noSend           - Optional, if `true`, won't send events.
+ * @param {string=} config.configId          - Optional
+ * @param {string=} config.session           - Optional
+ * @param {string=} config.cookieDomain      - Optional
  *
  * @return {Tracking} - Returns the tracking object
  */

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -35,7 +35,7 @@ function Tracking() {
 /**
  * Turn on/off developer mode. (Can also be activated on init.)
  * @param {boolean} level - Turn on or off, defaults to false if omitted.
- * @return {undefined}
+ * @return {void}
  */
 Tracking.prototype.developer = function(level) {
 	if (level) {
@@ -48,7 +48,7 @@ Tracking.prototype.developer = function(level) {
 
 /**
  * Clean up the tracking module.
- * @return {undefined}
+ * @return {void}
  */
 Tracking.prototype.destroy = function() {
 	this.developer(false);

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -151,10 +151,10 @@ Tracking.prototype.init = function(config = {}) {
 
 	settings.set('page_sent', false);
 
-	const cookieDomain = config ? config.cookieDomain : false;
+	const cookieDomain = config ? config.cookieDomain : '';
 
 	// Set up the user from stored - may later be updated by config
-	user.init(false, cookieDomain);
+	user.init('', cookieDomain);
 	this.updateConfig(config);
 
 	// Session

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -129,14 +129,13 @@ Tracking.prototype.getRootID = core.getRootID;
  *
  * @return {Tracking} - Returns the tracking object
  */
-Tracking.prototype.init = function(config) {
+Tracking.prototype.init = function(config = {}) {
 	if (this.initialised) {
 		return this;
 	}
 
 	const hasDeclarativeConfig = Boolean(this._getDeclarativeConfigElement());
 
-	config = config || {};
 	if (hasDeclarativeConfig) {
 		config = this._getDeclarativeConfig(config);
 	}

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -182,32 +182,6 @@ function getValueFromUrl(matcher) {
 }
 
 /**
- * Get a value from a specified JavaScript variable.
- * @param {String} str - The name of variable, in dot syntax.
- * @return {String} The value from the JS variable.
- */
-function getValueFromJsVariable(str) {
-	if (typeof str !== 'string') {
-		return null;
-
-	}
-
-	let i;
-	const namespaces = str.split('.');
-	let test = window;
-
-	for (i = 0; i < namespaces.length; i = i + 1) {
-		if (typeof test[namespaces[i]] === 'undefined') {
-			return null;
-		}
-
-		test = test[namespaces[i]];
-	}
-
-	return test !== '' ? test : null;
-}
-
-/**
  * Filter an object to only have the properties which are listed in the `allowlist` parameter.
  * @param {Object} objectToFilter - An object whose props need to be filtered
  * @param {Array} allowedPropertyNames - The list of props to allow
@@ -360,7 +334,6 @@ export default {
 	triggerPage,
 	getValueFromCookie,
 	getValueFromUrl,
-	getValueFromJsVariable,
 	sanitise,
 	assignIfUndefined,
 	filterProperties,
@@ -381,7 +354,6 @@ export {
 	triggerPage,
 	getValueFromCookie,
 	getValueFromUrl,
-	getValueFromJsVariable,
 	sanitise,
 	assignIfUndefined,
 	filterProperties,

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -18,7 +18,7 @@ const page_callbacks = [];
  * Log messages to the browser console. Requires 'log' to be set on init.
  *
  * @param {*} List of objects to log
- * @return {undefined}
+ * @return {void}
  */
 function log() {
 	if (settings.get('developer') && window.console) {
@@ -146,7 +146,7 @@ function broadcast(namespace, eventType, detail) {
  * Listen for page tracking requests.
  *
  * @param {Function} cb - The callback to be called whenever a page is tracked.
- * @return {undefined}
+ * @return {void}
  */
 function onPage(cb) {
 	if (is(cb, 'function')) {
@@ -156,7 +156,7 @@ function onPage(cb) {
 
 /**
  * Trigger the 'page' listeners.
- * @return {undefined}
+ * @return {void}
  */
 function triggerPage() {
 	for (let i = 0; i < page_callbacks.length; i++) {

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -36,10 +36,7 @@ function log() {
  *
  * @return {boolean} - The answer for if the variable is of type.
  */
-function is(variable, type) {
-	if (!type) {
-		type = 'undefined';
-	}
+function is(variable, type = 'undefined') {
 	return typeof variable === type;
 }
 

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -32,7 +32,7 @@ function log() {
  * Tests if variable is a certain type. Defaults to check for undefined if no type specified.
  *
  * @param {*} variable - The variable to check.
- * @param {string} type - The type to test for. Defaults to undefined.
+ * @param {string=} type - The type to test for. Defaults to undefined.
  *
  * @return {boolean} - The answer for if the variable is of type.
  */

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -173,15 +173,6 @@ function getValueFromCookie(matcher) {
 }
 
 /**
- * Get a value from the url, used for uuid or querystring parameters
- * @param {RegExp} matcher - The Regex to match with
- * @return {String} - The value from the URL
- */
-function getValueFromUrl(matcher) {
-	return document.location.href.match(matcher) && RegExp.$1 !== '' ? RegExp.$1 : null;
-}
-
-/**
  * Filter an object to only have the properties which are listed in the `allowlist` parameter.
  * @param {Object} objectToFilter - An object whose props need to be filtered
  * @param {Array} allowedPropertyNames - The list of props to allow
@@ -333,7 +324,6 @@ export default {
 	onPage,
 	triggerPage,
 	getValueFromCookie,
-	getValueFromUrl,
 	sanitise,
 	assignIfUndefined,
 	filterProperties,
@@ -353,7 +343,6 @@ export {
 	onPage,
 	triggerPage,
 	getValueFromCookie,
-	getValueFromUrl,
 	sanitise,
 	assignIfUndefined,
 	filterProperties,

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -17,13 +17,13 @@ const page_callbacks = [];
 /**
  * Log messages to the browser console. Requires 'log' to be set on init.
  *
- * @param {*} List of objects to log
+ * @param {*} args items to log
  * @return {void}
  */
-function log() {
+function log(...args) {
 	if (settings.get('developer') && window.console) {
-		for (let i=0;i<arguments.length;i++) {
-			window.console.log(arguments[i]);
+		for (const arg of args) {
+			window.console.log(arg);
 		}
 	}
 }

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -1,6 +1,5 @@
 /**
  * Shared 'internal' scope.
- * @private
  */
 import settings from './core/settings';
 

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -262,7 +262,7 @@ function findCircularPathsIn(rootObject) {
 /**
  * Used to find out whether an object contains a circular reference.
  * @param {*} rootObject The object we want to search within for circular references
- * @returns {bool} Returns true if a circular reference was found, otherwise returns false
+ * @returns {Boolean} Returns true if a circular reference was found, otherwise returns false
  */
 function containsCircularPaths(rootObject) {
 	// Used to keep track of all the values the rootObject contains

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -63,10 +63,6 @@ describe('Utils', function () {
 		proclaim.ok(Utils.getValueFromCookie);
 	});
 
-	it('should provide getValueFromUrl functionality', function () {
-		proclaim.ok(Utils.getValueFromUrl);
-	});
-
 	it('should provide sanitise functionality', function () {
 		[
 			{ param: '   with space  ', result: 'with space' },

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -67,15 +67,11 @@ describe('Utils', function () {
 		proclaim.ok(Utils.getValueFromUrl);
 	});
 
-	it('should provide getValueFromJsVariable functionality', function () {
-		proclaim.ok(Utils.getValueFromJsVariable);
-	});
-
 	it('should provide sanitise functionality', function () {
 		[
 			{ param: '   with space  ', result: 'with space' },
 			{ param: 'noSpace', result: 'noSpace' }
-	 	].forEach(function (test) {
+		].forEach(function (test) {
 			proclaim.equal(Utils.sanitise(test.param), test.result);
 		});
 	});


### PR DESCRIPTION
I turned on JSDoc type-checking in my editor and came across lots of errors which stemmed from incorrect JSDoc comments. This pull-requests fixes the JSDoc so that o-tracking has no more incorrect errors. Some of the changes had to be done to the code for the JSDoc type-inference to kick in, such as replacing a reduce function with a for-of loop.