### PR TITLE
Turn the tracking class into a singleton object as tracking is only meant to be used as a singleton

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,4 @@
-import { Tracking } from './src/javascript/tracking';
-
-const tracking = new Tracking();
+import tracking from './src/javascript/tracking';
 
 function initialise() {
 	tracking.init();
@@ -15,6 +13,6 @@ document.addEventListener('o.DOMContentLoaded', initialise);
  * A constructed object, this module is a Singleton as we only want one
  * instance sending events. See {@link Tracking} for the publicly available
  * interface.
- * @type {Tracking}
+ * @type {tracking}
  */
 export default tracking;

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -114,7 +114,7 @@ function toString() {
  * @param {object=} config.system            - Optional
  * @param {object=} config.device            - Optional
  *
- * @return {tracking} - The initialised tracking object.
+ * @return {tracking|null} - The initialised tracking object or null if no configuration has been given.
  */
 function init(config = {}) {
 	if (tracking.initialised) {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -15,6 +15,30 @@ describe('main', function () {
 		settings.destroy('config'); // Empty settings.
 	});
 
+	it('should only allow a single tracking instance to exist', function() {
+		oTracking.destroy();
+		const confEl = document.createElement('script');
+		confEl.type = 'application/json';
+		confEl.dataset.oTrackingConfig = 'true';
+		const config = {
+			context: {
+				product: 'desktop'
+			},
+			user: {
+				user_id: '023ur9jfokwenvcklwnfiwhfoi324'
+			}
+		};
+		confEl.innerText = JSON.stringify(config);
+
+		document.head.appendChild(confEl);
+		const tracking1 = oTracking.init();
+		const tracking2 = oTracking.init();
+		document.head.removeChild(confEl);
+		proclaim.deepStrictEqual(tracking1, oTracking);
+		proclaim.deepStrictEqual(tracking1, tracking2);
+		oTracking.destroy();
+	});
+
 	it('should quit without any config to init with', function() {
 		oTracking.destroy();
 		const tracking = oTracking.init();


### PR DESCRIPTION
The Tracking class is only ever meant to be used as a singleton object, let's make the implementation enforce that it can only be used as a singleton and not have multiple tracking instances by mistake.

This should not change anything for users of o-tracking as the exported interface is the same.