### PR TITLE
Breaking: Always use the Beacon API if it exists.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,6 +3,8 @@
 
 ## Migrating from v2 to v3
 
+o-tracking now uses the Beacon API in all browsers which support it. In v2 this was an opt-in feature, now it is always enabled in browsers which support it. For browsers which do not support Beacon API o-tracking will revert to the XMLHTTPRequest API.
+
 The `Tracking.prototype.utils` object has been removed.
 
 The methods `setDomain` and `getDomain` have been removed, o-tracking only works with the spoor domain, which is set automatically.

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -57,6 +57,14 @@ function sendRequest(request, callback) {
 	utils.log('user_callback', user_callback);
 	utils.log('PreSend', request);
 
+	if (utils.containsCircularPaths(request)) {
+		const errorMessage = "o-tracking does not support circular references in the analytics data.\n" +
+		"Please remove the circular references in the data.\n" +
+		"Here are the paths in the data which are circular:\n" +
+		JSON.stringify(utils.findCircularPathsIn(request), undefined, 4);
+		throw new Error(errorMessage);
+	}
+
 	const stringifiedData = JSON.stringify(request);
 
 	transport.complete(function (error) {

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -16,7 +16,7 @@ let queue;
  * @return {boolean} Should we use sendBeacon?
  */
 function should_use_sendBeacon() {
-	return navigator.sendBeacon && Promise && (settings.get('config') || {}).useSendBeacon;
+	return Boolean(navigator.sendBeacon);
 }
 
 /**

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -61,35 +61,16 @@ describe('Core.Send', function () {
 			setup.mockTransport();
 		});
 
-		it('use xhr by default', function (done) {
+		it('use sendBeacon by default', function (done) {
+			sinon.stub(navigator, 'sendBeacon');
 			Send.init();
-			navigator.sendBeacon = navigator.sendBeacon || true;
-			const xhr = window.XMLHttpRequest;
-			const dummyXHR = {
-				withCredentials: false,
-				open: sinon.stub(),
-				setRequestHeader: sinon.stub(),
-				send: sinon.stub()
-			};
-			window.XMLHttpRequest = function () {
-				return dummyXHR;
-			};
 			Send.addAndRun(request);
 			setTimeout(() => {
 				try {
-					proclaim.equal(typeof dummyXHR.onerror, 'function');
-					proclaim.equal(typeof dummyXHR.onload, 'function');
-					// proclaim.equal(dummyXHR.onerror.length, 1) // it will get passed the error
-					// proclaim.equal(dummyXHR.onload.length, 0) // it will not get passed an error
-					proclaim.ok(dummyXHR.withCredentials);
-
-					proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/px.gif?type=video:seek", true));
-					proclaim.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'));
-					proclaim.ok(dummyXHR.send.calledOnce);
-					window.XMLHttpRequest = xhr;
-					if (typeof navigator.sendBeacon === 'boolean') {
-						delete navigator.sendBeacon;
-					}
+					proclaim.equal(navigator.sendBeacon.args[0][0], 'https://spoor-api.ft.com/px.gif?type=video:seek');
+					proclaim.ok(navigator.sendBeacon.called);
+					navigator.sendBeacon.restore();
+					settings.destroy('config');
 					done();
 				} catch (error) {
 					done(error);
@@ -97,30 +78,9 @@ describe('Core.Send', function () {
 			}, 100);
 		});
 
-		if (navigator.sendBeacon) {
-			it('use sendBeacon when configured', function (done) {
-				settings.set('config', {useSendBeacon: true});
-				sinon.stub(navigator, 'sendBeacon');
-				Send.init();
-				Send.addAndRun(request);
-				setTimeout(() => {
-					try {
-						proclaim.equal(navigator.sendBeacon.args[0][0], 'https://spoor-api.ft.com/px.gif?type=video:seek');
-						proclaim.ok(navigator.sendBeacon.called);
-						navigator.sendBeacon.restore();
-						settings.destroy('config');
-						done();
-					} catch (error) {
-						done(error);
-					}
-				}, 100);
-			});
-		}
-
 
 		it('fallback to xhr when sendBeacon not supported', function (done) {
 			new Queue('requests').replace([]);
-			settings.set('config', {useSendBeacon: true});
 			Send.init();
 			const b = navigator.sendBeacon;
 			navigator.sendBeacon = null;

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -76,20 +76,24 @@ describe('Core.Send', function () {
 			};
 			Send.addAndRun(request);
 			setTimeout(() => {
-				proclaim.equal(typeof dummyXHR.onerror, 'function');
-				proclaim.equal(typeof dummyXHR.onload, 'function');
-				// proclaim.equal(dummyXHR.onerror.length, 1) // it will get passed the error
-				// proclaim.equal(dummyXHR.onload.length, 0) // it will not get passed an error
-				proclaim.ok(dummyXHR.withCredentials);
+				try {
+					proclaim.equal(typeof dummyXHR.onerror, 'function');
+					proclaim.equal(typeof dummyXHR.onload, 'function');
+					// proclaim.equal(dummyXHR.onerror.length, 1) // it will get passed the error
+					// proclaim.equal(dummyXHR.onload.length, 0) // it will not get passed an error
+					proclaim.ok(dummyXHR.withCredentials);
 
-				proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/px.gif?type=video:seek", true));
-				proclaim.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'));
-				proclaim.ok(dummyXHR.send.calledOnce);
-				window.XMLHttpRequest = xhr;
-				if (typeof navigator.sendBeacon === 'boolean') {
-					delete navigator.sendBeacon;
+					proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/px.gif?type=video:seek", true));
+					proclaim.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'));
+					proclaim.ok(dummyXHR.send.calledOnce);
+					window.XMLHttpRequest = xhr;
+					if (typeof navigator.sendBeacon === 'boolean') {
+						delete navigator.sendBeacon;
+					}
+					done();
+				} catch (error) {
+					done(error);
 				}
-				done();
 			}, 100);
 		});
 
@@ -100,11 +104,15 @@ describe('Core.Send', function () {
 				Send.init();
 				Send.addAndRun(request);
 				setTimeout(() => {
-					proclaim.equal(navigator.sendBeacon.args[0][0], 'https://spoor-api.ft.com/px.gif?type=video:seek');
-					proclaim.ok(navigator.sendBeacon.called);
-					navigator.sendBeacon.restore();
-					settings.destroy('config');
-					done();
+					try {
+						proclaim.equal(navigator.sendBeacon.args[0][0], 'https://spoor-api.ft.com/px.gif?type=video:seek');
+						proclaim.ok(navigator.sendBeacon.called);
+						navigator.sendBeacon.restore();
+						settings.destroy('config');
+						done();
+					} catch (error) {
+						done(error);
+					}
 				}, 100);
 			});
 		}
@@ -128,18 +136,22 @@ describe('Core.Send', function () {
 			};
 			Send.addAndRun(request);
 			setTimeout(() => {
-				proclaim.equal(typeof dummyXHR.onerror, 'function');
-				proclaim.equal(typeof dummyXHR.onload, 'function');
-				// proclaim.equal(dummyXHR.onerror.length, 1) // it will get passed the error
-				// proclaim.equal(dummyXHR.onload.length, 0) // it will not get passed an error
-				proclaim.ok(dummyXHR.withCredentials, 'withCredentials');
-				proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/px.gif?type=video:seek", true), 'is POST');
-				proclaim.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'), 'is application/json');
-				proclaim.ok(dummyXHR.send.calledOnce, 'calledOnce');
-				window.XMLHttpRequest = xhr;
-				navigator.sendBeacon = b;
-				settings.destroy('config');
-				done();
+				try {
+					proclaim.equal(typeof dummyXHR.onerror, 'function');
+					proclaim.equal(typeof dummyXHR.onload, 'function');
+					// proclaim.equal(dummyXHR.onerror.length, 1) // it will get passed the error
+					// proclaim.equal(dummyXHR.onload.length, 0) // it will not get passed an error
+					proclaim.ok(dummyXHR.withCredentials, 'withCredentials');
+					proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/px.gif?type=video:seek", true), 'is POST');
+					proclaim.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'), 'is application/json');
+					proclaim.ok(dummyXHR.send.calledOnce, 'calledOnce');
+					window.XMLHttpRequest = xhr;
+					navigator.sendBeacon = b;
+					settings.destroy('config');
+					done();
+				} catch (error) {
+					done(error);
+				}
 			}, 100);
 		});
 
@@ -159,15 +171,19 @@ describe('Core.Send', function () {
 			window.Image = sinon.stub().returns(dummyImage);
 			Send.addAndRun(request);
 			setTimeout(() => {
-				proclaim.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
-				proclaim.equal(dummyImage.addEventListener.args[0][0], 'error');
-				proclaim.equal(dummyImage.addEventListener.args[0][1].length, 1);// it will get passed the error
-				proclaim.equal(dummyImage.addEventListener.args[1][0], 'load');
-				proclaim.equal(dummyImage.addEventListener.args[1][1].length, 0);// it will get passed the error
-				window.XMLHttpRequest = xhr;
-				window.Image = i;
-				navigator.sendBeacon = b;
-				done();
+				try {
+					proclaim.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
+					proclaim.equal(dummyImage.addEventListener.args[0][0], 'error');
+					proclaim.equal(dummyImage.addEventListener.args[0][1].length, 1);// it will get passed the error
+					proclaim.equal(dummyImage.addEventListener.args[1][0], 'load');
+					proclaim.equal(dummyImage.addEventListener.args[1][1].length, 0);// it will get passed the error
+					window.XMLHttpRequest = xhr;
+					window.Image = i;
+					navigator.sendBeacon = b;
+					done();
+				} catch (error) {
+					done(error);
+				}
 			}, 100);
 		});
 
@@ -186,15 +202,19 @@ describe('Core.Send', function () {
 			window.Image = sinon.stub().returns(dummyImage);
 			Send.addAndRun(request);
 			setTimeout(() => {
-				proclaim.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
-				proclaim.equal(dummyImage.attachEvent.args[0][0], 'onerror');
-				proclaim.equal(dummyImage.attachEvent.args[0][1].length, 1);// it will get passed the error
-				proclaim.equal(dummyImage.attachEvent.args[1][0], 'onload');
-				proclaim.equal(dummyImage.attachEvent.args[1][1].length, 0);// it will get passed the error
-				window.XMLHttpRequest = xhr;
-				window.Image = i;
-				navigator.sendBeacon = b;
-				done();
+				try {
+					proclaim.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
+					proclaim.equal(dummyImage.attachEvent.args[0][0], 'onerror');
+					proclaim.equal(dummyImage.attachEvent.args[0][1].length, 1);// it will get passed the error
+					proclaim.equal(dummyImage.attachEvent.args[1][0], 'onload');
+					proclaim.equal(dummyImage.attachEvent.args[1][1].length, 0);// it will get passed the error
+					window.XMLHttpRequest = xhr;
+					window.Image = i;
+					navigator.sendBeacon = b;
+					done();
+				} catch (error) {
+					done(error);
+				}
 			}, 100);
 		});
 
@@ -221,10 +241,14 @@ describe('Core.Send', function () {
 			setTimeout(() => {
 				// console.log((new Queue('requests')).all());
 
-				proclaim.ok(new Queue('requests').last().queueTime);
-				navigator.sendBeacon = b;
-				server.restore();
-				done();
+				try {
+					proclaim.ok(new Queue('requests').last().queueTime);
+					navigator.sendBeacon = b;
+					server.restore();
+					done();
+				} catch (error) {
+					done(error);
+				}
 			}, 100);
 		});
 	});
@@ -252,15 +276,19 @@ describe('Core.Send', function () {
 
 		// Wait for localStorage
 		setTimeout(() => {
-			// Refresh our queue as it's kept in memory
-			queue = new Queue('requests');
+			try {
+				// Refresh our queue as it's kept in memory
+				queue = new Queue('requests');
 
-			// Event added for the debugging info
-			proclaim.equal(queue.all().length, 0);
+				// Event added for the debugging info
+				proclaim.equal(queue.all().length, 0);
 
-			// console.log(queue.all());
-			server.restore();
-			done();
+				// console.log(queue.all());
+				server.restore();
+				done();
+			} catch (error) {
+				done(error);
+			}
 		}, 200);
 	});
 

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -59,11 +59,14 @@ describe('click', function () {
 		aLinkToGoogle.dispatchEvent(event, true);
 
 		setTimeout(() => {
+			try {
+				proclaim.equal(core.track.calledOnce, true, "click event tracked");
 
-			proclaim.equal(core.track.calledOnce, true, "click event tracked");
-
-			core.track.restore();
-			done();
+				core.track.restore();
+				done();
+			} catch (error) {
+				done(error);
+			}
 
 		}, 10);
 
@@ -96,10 +99,14 @@ describe('click', function () {
 		aLinkToGoogle.dispatchEvent(event, true);
 
 		setTimeout(() => {
-			proclaim.equal(core.track.getCall(0).args[0].context.foo, 'bar');
+			try {
+				proclaim.equal(core.track.getCall(0).args[0].context.foo, 'bar');
 
-			core.track.restore();
-			done();
+				core.track.restore();
+				done();
+			} catch (error) {
+				done(error);
+			}
 		}, 10);
 
 	});
@@ -132,10 +139,14 @@ describe('click', function () {
 
 		setTimeout(() => {
 
-			proclaim.equal(core.track.notCalled, true, "click event not tracked");
+			try {
+				proclaim.equal(core.track.notCalled, true, "click event not tracked");
 
-			core.track.restore();
-			done();
+				core.track.restore();
+				done();
+			} catch (error) {
+				done(error);
+			}
 
 		}, 10);
 
@@ -169,10 +180,14 @@ describe('click', function () {
 		aLinkToPageOnSameDomain.dispatchEvent(event, true);
 
 		setTimeout(() => {
-			proclaim.equal(core.track.notCalled, true, "click event not tracked");
+			try {
+				proclaim.equal(core.track.notCalled, true, "click event not tracked");
 
-			core.track.restore();
-			done();
+				core.track.restore();
+				done();
+			} catch (error) {
+				done(error);
+			}
 
 		}, 10);
 
@@ -207,10 +222,14 @@ describe('click', function () {
 		aLinkToPageOnSameDomain.dispatchEvent(event, true);
 
 		setTimeout(() => {
-			proclaim.equal(core.track.calledOnce, true, "click event not tracked");
+			try {
+				proclaim.equal(core.track.calledOnce, true, "click event not tracked");
 
-			core.track.restore();
-			done();
+				core.track.restore();
+				done();
+			} catch (error) {
+				done(error);
+			}
 
 		}, 10);
 

--- a/test/events/custom.test.js
+++ b/test/events/custom.test.js
@@ -96,7 +96,7 @@ describe('event', function () {
 Please remove the circular references in the data.
 Here are the paths in the data which are circular:
 [
-    "[0].item.context.context.circular"
+    ".context.context.circular"
 ]`;
 		proclaim.throws(function(){
 			trackEvent(


### PR DESCRIPTION
Previously we had the Beacon API be an opt-in system.

Every browser except for Internet Explorer now supports Beacon API (https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon#Browser_compatibility) so we should use it by default and fallback to XHR for Internet Explorer.

Beacon API was purpose built for tracking/analytics requests.

With the Beacon API, data is transmitted asynchronously when the User Agent has an opportunity to do so, without delaying the next navigation (If the browser was navigating to a new page).
