### PR TITLE
Refactor: Use Object.assign instead of a for-in loop inside getDeclarativeConfig function

### DIFF
--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -184,10 +184,9 @@ function getDeclarativeConfig(options) {
 		return false;
 	}
 
-	let declarativeOptions;
-
 	try {
-		declarativeOptions = JSON.parse(declarativeConfigString);
+		const declarativeOptions = JSON.parse(declarativeConfigString);
+		Object.assign(options, declarativeOptions);
 	} catch(e) {
 		const configError = new Error('Invalid JSON configuration syntax, check validity for o-tracking configuration: "' + e.message + '"');
 		broadcast('oErrors', 'log', {
@@ -195,12 +194,6 @@ function getDeclarativeConfig(options) {
 			info: { module: 'o-tracking' }
 		});
 		throw configError;
-	}
-
-	for (const property in declarativeOptions) {
-		if (Object.prototype.hasOwnProperty.call(declarativeOptions, property)) {
-			options[property] = options[property] || declarativeOptions[property];
-		}
 	}
 
 	return options;


### PR DESCRIPTION
Hopefully this is easier to understand than the for-in loop