### PR TITLE
 Replace developer mode with test mode and send the event to Spoor with `is_live` set to false.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,7 +28,7 @@ The `tracking.developer` function has been removed, it has been replaced by a co
 ```
 
 
-The configuration parameter `no_send` has been removed, it has been replaced by the configuration parameter `test`. Set `test` to `true` to turn send events in test mode.
+The configuration parameter `no_send` has been removed, it has been replaced by a configuration parameter named `test`. The events will be sent but will be marked as test events, which Spoor will ignore.
 ```diff
 -tracking.init({
 -	no_send: true

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -19,7 +19,7 @@ The deprecated `user.passport_id` data property has been removed.
 +tracking.click.init();
 ```
 
-`tracking.developer` has been removed, it has been replaced by the configuration parameter `test`. Set `test` to `true` to turn send events in test mode.
+The `tracking.developer` function has been removed, it has been replaced by a configuration parameter named `test`. Set the `test` configuration parameter to `true` to have similar behavior to the old `developer` mode.
 ```diff
 -tracking.developer(true);
 +tracking.init({

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,10 +21,19 @@ The deprecated `user.passport_id` data property has been removed.
 ```diff
 -tracking.developer(true);
 +tracking.init({
-    test: true
-});
++    test: true
++});
 ```
 
+
+The configuration parameter `no_send` has been removed, it has been replaced by the configuration parameter `test`. Set `test` to `true` to turn send events in test mode.
+```diff
+-tracking.init({
+-	no_send: true
+-});
++tracking.init({
++    test: true
++});
 The export interface now only has a single default export. All the named exports have been removed.
 
 ```diff

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -17,6 +17,14 @@ The deprecated `user.passport_id` data property has been removed.
 +tracking.click.init();
 ```
 
+`tracking.developer` has been removed, it has been replaced by the configuration parameter `test`. Set `test` to `true` to turn send events in test mode.
+```diff
+-tracking.developer(true);
++tracking.init({
+    test: true
+});
+```
+
 The export interface now only has a single default export. All the named exports have been removed.
 
 ```diff

--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ Here is the corresponding tracking pixel setup:
 
 ### Tracking with JavaScript
 
+#### Developer/Test Mode
+
+O-tracking has a development/test mode which will mark the events as test events, and also write to the console extra debugging information.
+
+To activate the mode, set `test` to `true` during the intialisation of `o-tracking` like so:
+
+```js
+import oTracking from 'o-tracking';
+
+const config = {
+    test: true, // Mark the events as test events and turn on extra debug logging.
+    ...
+};
+oTracking.init(config);
+```
+
 #### Methods
 
 ##### oTracking.init

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here is the corresponding tracking pixel setup:
 
 #### Developer/Test Mode
 
-O-tracking has a development/test mode which will mark the events as test events, and also write to the console extra debugging information.
+o-tracking has a development/test mode which will mark the events as test events, and also write to the console extra debugging information.
 
 To activate the mode, set `test` to `true` during the intialisation of `o-tracking` like so:
 

--- a/docs/event-parameters/page-view.md
+++ b/docs/event-parameters/page-view.md
@@ -546,26 +546,6 @@ oTracking.init({
 });
 ```
 
-### system_is_live
-
-- Key: `system.is_live`
-- Required: no
-- Default: true
-- o-tracking automatic: no
-- spoor pipeline automatic: no
-
-A boolean value identifying the live system. As we can't work out all the possible values from `system.environment` above, we use this boolean to filter out test traffic.
-
-If using o-tracking, this is usually set at init e.g.
-
-```js
-oTracking.init({
-  system: {
-    is_live: true
-  }
-});
-```
-
 ### system_ticket
 
 - Key: `ingest._headers.spoor-ticket`

--- a/docs/event-parameters/text-copy.md
+++ b/docs/event-parameters/text-copy.md
@@ -219,26 +219,6 @@ oTracking.init({
 });
 ```
 
-### system_is_live
-
-- Key: `system.is_live`
-- Required: no
-- Default: true
-- o-tracking automatic: no
-- spoor pipeline automatic: no
-
-A boolean value identifying the live system. As we can't work out all the possible values from `system.environment` above, we use this boolean to filter out test traffic.
-
-If using o-tracking, this is usually set at init e.g.
-
-```js
-oTracking.init({
-  system: {
-    is_live: true
-  }
-});
-```
-
 ### system_ticket
 
 - Key: `ingest._headers.spoor-ticket`

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -42,6 +42,13 @@ function sendRequest(request, callback) {
 		transport: transport.name, // The transport method used.
 	});
 
+	if (settings.get('config').test) {
+		system.is_live = false;
+	} else {
+		system.is_live = true;
+	}
+
+
 	request = utils.merge({ system: system }, request);
 
 	// Only bothered about offlineLag if it's longer than a second, but less than 12 months. (Especially as Date can be dodgy)
@@ -88,10 +95,7 @@ function sendRequest(request, callback) {
 		url += `?type=${request.category}:${request.action}`;
 	}
 
-	// Both developer and noSend flags have to be set to stop the request sending.
-	if (!(settings.get('developer') && settings.get('no_send'))) {
-		transport.send(url, stringifiedData);
-	}
+	transport.send(url, stringifiedData);
 }
 
 /**

--- a/src/javascript/core/settings.js
+++ b/src/javascript/core/settings.js
@@ -1,5 +1,5 @@
 
-const settings = {};
+const settings = {config:{}};
 
 /**
  * Very basic implementation of deep clone, and only supports simple POJO objects and

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -37,32 +37,8 @@ function updateConfig(newConfig) {
 	config = merge(config, newConfig);
 	settings.set('config', config);
 
-	// Developer mode
-	if (config.developer) {
-		developer(config.developer);
-
-		if (config.noSend) {
-			settings.set('no_send', true);
-		}
-	}
-
 	if (config.user && config.user.user_id) {
 		user.setUser(config.user.user_id);
-	}
-}
-
-/**
- * Turn on/off developer mode. (Can also be activated on init.)
- * @param {boolean} level - Turn on or off, defaults to false if omitted.
- * @return {void}
-
- */
-function developer(level) {
-	if (level) {
-		settings.set('developer', true);
-	} else {
-		settings.destroy('developer');
-		settings.destroy('no_send');
 	}
 }
 
@@ -71,7 +47,6 @@ function developer(level) {
  * @return {void}
  */
 function destroy() {
-	developer(false);
 	tracking.initialised = false;
 
 	settings.destroy('config');
@@ -104,8 +79,7 @@ function toString() {
  * </script>
  *
  * @param {Object} config 					- See {@link Tracking} for the configuration options.
- * @param {boolean=} config.developer        - Optional, if `true`, logs certain actions.
- * @param {boolean=} config.noSend           - Optional, if `true`, won't send events.
+ * @param {boolean=} config.test             - Optional, if `true`, the data sent to Spoor will be marked as test data.
  * @param {string=} config.configId          - Optional
  * @param {string=} config.session           - Optional
  * @param {string=} config.cookieDomain      - Optional
@@ -215,7 +189,6 @@ const tracking = {
 	version,
 	updateConfig,
 	source,
-	developer,
 	destroy,
 	toString,
 	init,

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -20,7 +20,7 @@ const page_callbacks = [];
  * @return {void}
  */
 function log(...args) {
-	if (settings.get('developer') && window.console) {
+	if (settings.get('config').test && window.console) {
 		for (const arg of args) {
 			window.console.log(arg);
 		}

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -62,7 +62,7 @@ describe('Core', function () {
 			const sent_data = callback.getCall(0).thisValue;
 			proclaim.deepEqual(Object.keys(sent_data), ["system","context","user","device","category","action"]);
 			// System
-			proclaim.deepEqual(Object.keys(sent_data.system), ["version","source"]);
+			proclaim.deepEqual(Object.keys(sent_data.system), ["version","source", "is_live"]);
 			proclaim.equal(sent_data.system.version, "1.0.0");
 			proclaim.equal(sent_data.system.source, "o-tracking");
 

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -33,6 +33,9 @@ import settings from '../../src/javascript/core/settings';
 // PhantomJS doesn't always create a "fresh" environment...
 
 describe('Core.Send', function () {
+	beforeEach(function() {
+		settings.set('config', {});
+	});
 
 	after(function () {
 		new Queue('requests').replace([]);
@@ -159,15 +162,20 @@ describe('Core.Send', function () {
 			window.Image = sinon.stub().returns(dummyImage);
 			Send.addAndRun(request);
 			setTimeout(() => {
-				proclaim.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
-				proclaim.equal(dummyImage.addEventListener.args[0][0], 'error');
-				proclaim.equal(dummyImage.addEventListener.args[0][1].length, 1);// it will get passed the error
-				proclaim.equal(dummyImage.addEventListener.args[1][0], 'load');
-				proclaim.equal(dummyImage.addEventListener.args[1][1].length, 0);// it will get passed the error
-				window.XMLHttpRequest = xhr;
-				window.Image = i;
-				navigator.sendBeacon = b;
-				done();
+				try {
+					const payload = dummyImage.src.split('?')[1];
+					proclaim.equal(decodeURIComponent(payload), 'type=video:seek&data={"system":{"transport":"image","is_live":true},"id":"1.199.83760034665465.1432907605043.-56cf00f","meta":{"page_id":"page_id","type":"event"},"user":{"spoor_session":"MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg==","spoor_id":"value3"},"device":{"user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.8 Safari/534.34"},"category":"video","action":"seek","context":{"key":"pos","value":"10","parent_id":"1.990.74606760405.1432907605040.-56cf00f"}}');
+					proclaim.equal(dummyImage.addEventListener.args[0][0], 'error');
+					proclaim.equal(dummyImage.addEventListener.args[0][1].length, 1);// it will get passed the error
+					proclaim.equal(dummyImage.addEventListener.args[1][0], 'load');
+					proclaim.equal(dummyImage.addEventListener.args[1][1].length, 0);// it will get passed the error
+					window.XMLHttpRequest = xhr;
+					window.Image = i;
+					navigator.sendBeacon = b;
+					done();
+				} catch (error) {
+					done(error);
+				}
 			}, 100);
 		});
 
@@ -186,15 +194,20 @@ describe('Core.Send', function () {
 			window.Image = sinon.stub().returns(dummyImage);
 			Send.addAndRun(request);
 			setTimeout(() => {
-				proclaim.equal(dummyImage.src, 'https://spoor-api.ft.com/px.gif?type=video:seek&data=%7B%22system%22%3A%7B%22transport%22%3A%22image%22%7D%2C%22id%22%3A%221.199.83760034665465.1432907605043.-56cf00f%22%2C%22meta%22%3A%7B%22page_id%22%3A%22page_id%22%2C%22type%22%3A%22event%22%7D%2C%22user%22%3A%7B%22spoor_session%22%3A%22MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg%3D%3D%22%2C%22spoor_id%22%3A%22value3%22%7D%2C%22device%22%3A%7B%22user_agent%22%3A%22Mozilla%2F5.0%20(Macintosh%3B%20Intel%20Mac%20OS%20X)%20AppleWebKit%2F534.34%20(KHTML%2C%20like%20Gecko)%20PhantomJS%2F1.9.8%20Safari%2F534.34%22%7D%2C%22category%22%3A%22video%22%2C%22action%22%3A%22seek%22%2C%22context%22%3A%7B%22key%22%3A%22pos%22%2C%22value%22%3A%2210%22%2C%22parent_id%22%3A%221.990.74606760405.1432907605040.-56cf00f%22%7D%7D');
-				proclaim.equal(dummyImage.attachEvent.args[0][0], 'onerror');
-				proclaim.equal(dummyImage.attachEvent.args[0][1].length, 1);// it will get passed the error
-				proclaim.equal(dummyImage.attachEvent.args[1][0], 'onload');
-				proclaim.equal(dummyImage.attachEvent.args[1][1].length, 0);// it will get passed the error
-				window.XMLHttpRequest = xhr;
-				window.Image = i;
-				navigator.sendBeacon = b;
-				done();
+				try {
+					const payload = dummyImage.src.split('?')[1];
+					proclaim.equal(decodeURIComponent(payload), 'type=video:seek&data={"system":{"transport":"image","is_live":true},"id":"1.199.83760034665465.1432907605043.-56cf00f","meta":{"page_id":"page_id","type":"event"},"user":{"spoor_session":"MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg==","spoor_id":"value3"},"device":{"user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.8 Safari/534.34"},"category":"video","action":"seek","context":{"key":"pos","value":"10","parent_id":"1.990.74606760405.1432907605040.-56cf00f"}}');
+					proclaim.equal(dummyImage.attachEvent.args[0][0], 'onerror');
+					proclaim.equal(dummyImage.attachEvent.args[0][1].length, 1);// it will get passed the error
+					proclaim.equal(dummyImage.attachEvent.args[1][0], 'onload');
+					proclaim.equal(dummyImage.attachEvent.args[1][1].length, 0);// it will get passed the error
+					window.XMLHttpRequest = xhr;
+					window.Image = i;
+					navigator.sendBeacon = b;
+					done();
+				} catch (error) {
+					done(error);
+				}
 			}, 100);
 		});
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -172,8 +172,7 @@ describe('main', function () {
 
 		oTracking.init({
 			system: {
-				environment: 'prod',
-				is_live: true
+				environment: 'prod'
 			}
 		});
 
@@ -187,6 +186,76 @@ describe('main', function () {
 		const sent_data = callback.getCall(0).thisValue;
 
 		proclaim.equal(sent_data.system.environment, "prod");
+	});
+
+	it('should not allow system.is_live to be set on init', function () {
+		oTracking.destroy();
+
+		oTracking.init({
+			system: {
+				is_live: "carrot"
+			}
+		});
+
+
+		const callback = sinon.spy();
+
+		oTracking.page({}, callback);
+
+		proclaim.ok(callback.called, 'Callback not called.');
+
+		const sent_data = callback.getCall(0).thisValue;
+
+		proclaim.equal(sent_data.system.is_live, true);
+	});
+
+	it('should set system.is_live to be false if `test` is set to true', function () {
+		oTracking.destroy();
+
+		oTracking.init({
+			test: true
+		});
+
+
+		const callback = sinon.spy();
+
+		oTracking.page({}, callback);
+
+		proclaim.ok(callback.called, 'Callback not called.');
+
+		const sent_data = callback.getCall(0).thisValue;
+
+		proclaim.equal(sent_data.system.is_live, false);
+	});
+
+	it('should set system.is_live to be true if `test` is set to false', function () {
+		oTracking.destroy();
+
+		oTracking.init({
+			test: false
+		});
+
+
+		const callback = sinon.spy();
+
+		oTracking.page({}, callback);
+
+		proclaim.ok(callback.called, 'Callback not called.');
+
+		const sent_data = callback.getCall(0).thisValue;
+
+		proclaim.equal(sent_data.system.is_live, true);
+	});
+
+	it('should set system.is_live to be true if `test` is not set', function () {
+		const callback = sinon.spy();
+
+		oTracking.page({}, callback);
+
+		proclaim.ok(callback.called, 'Callback not called.');
+
+		const sent_data = callback.getCall(0).thisValue;
+
 		proclaim.equal(sent_data.system.is_live, true);
 	});
 


### PR DESCRIPTION
Chris Brown pointed out that `is_live` currently is not used to filter out test data but that it could be if o-tracking enforced a consistent setting, which is what o-tracking will now do.