### PR TITLE
Remove the cookie based storage fallback

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -43,6 +43,9 @@ The export interface now only has a single default export. All the named exports
 + import tracking from 'o-tracking';
 ```
 
+
+Using cookies as a storage mechanism for queuing up events to send to Spoor has been removed. The only available storage mechanism is localStorage. o-tracking v3 will read already existing queued events in a cookie and transfer them to localStorage. The reason to remove the cookie based storage machanism is because we were getting users who had their cookie size become too large and it was effecting the performance of the website (cookies were getting to be 5kb in size).
+
 ## Migrating from v1 to v2
 
 o-tracking v2 has dropped support for ftdomdelegate v3, please ensure your project is not using ftdomdelegate v3 and can work with ftdomdelegate v4.

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -6,9 +6,10 @@ import utils from '../utils';
  *
  * @class  Store
  * @param {string} name - The name of the store
- * @param {Object=} config - Optional, config object for extra configuration
+ * @param {Object} config - Optional, config object for extra configuration
+ * @param {String=} config.nameOverride - The internal name for the store
  */
-const Store = function (name, config) {
+const Store = function (name, config = {}) {
 
 	/**
 	 * Internal Storage key prefix.

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -17,7 +17,7 @@ const Store = function (name, config = {}) {
 	const keyPrefix = 'o-tracking';
 
 
-	if (utils.isUndefined(name)) {
+	if (typeof name !== 'string' || name === '') {
 		const undefinedName = new Error('You must specify a name for the store.');
 		utils.broadcast('oErrors', 'log', {
 			error: undefinedName.message,

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -36,7 +36,7 @@ const Store = function (name, config = {}) {
 	/**
 	 * The key/name of this store.
 	 */
-	this.storageKey = Object.prototype.hasOwnProperty.call(this.config, 'nameOverride') ? this.config.nameOverride : [keyPrefix, name].join('_');
+	this.storageKey = this.config.nameOverride ? this.config.nameOverride : [keyPrefix, name].join('_');
 
 	/**
 	 * The storage method to use.

--- a/test/core/store.test.js
+++ b/test/core/store.test.js
@@ -5,14 +5,54 @@ import Store from '../../src/javascript/core/store';
 
 describe('Core.Store', function () {
 
-	describe('init()', function () {
+	describe('constructor', function () {
+
+		it('throws an error if not given a name for the store', function() {
+			proclaim.throws(function() {
+				new Store;
+			});
+		});
+
+		it('throws an error if name for the store is not a string', function() {
+			proclaim.throws(function() {
+				new Store(137);
+			});
+			proclaim.throws(function() {
+				new Store({});
+			});
+			proclaim.throws(function() {
+				new Store(true);
+			});
+			proclaim.throws(function() {
+				new Store([]);
+			});
+			proclaim.throws(function() {
+				new Store(undefined);
+			});
+			proclaim.throws(function() {
+				new Store(null);
+			});
+			proclaim.throws(function() {
+				new Store(function(){});
+			});
+		});
+
+		it('throws an error if name for the store is an empty string', function() {
+			proclaim.throws(function() {
+				new Store('');
+			});
+		});
+
+		it('constructs a store if given a name which is a string', function() {
+			proclaim.doesNotThrow(function() {
+				new Store('test');
+			});
+		});
+
 		it('should use local storage by default', function () {
 			proclaim.equal(new Store('test').storage._type, 'localStorage');
 		});
 	});
-
-	const store = new Store('test');
-
 	describe('write()', function () {
 		it('should save a value', function () {
 			proclaim.equal(store.write('TESTING').read(), 'TESTING');

--- a/test/core/store.test.js
+++ b/test/core/store.test.js
@@ -6,20 +6,9 @@ import Store from '../../src/javascript/core/store';
 describe('Core.Store', function () {
 
 	describe('init()', function () {
-
 		it('should use local storage by default', function () {
 			proclaim.equal(new Store('test').storage._type, 'localStorage');
 		});
-
-		if (document.location.toString().match('^file://') && navigator.userAgent.indexOf('PhantomJS') > -1) {
-			it('should still work if there is no storage mechanism available', function () {
-				proclaim.equal(new Store('test', { storage: 'cookie' }).storage._type, 'none');
-			});
-		} else {
-			it('can use cookies for storage', function () {
-				proclaim.equal(new Store('test', { storage: 'cookie' }).storage._type, 'cookie');
-			});
-		}
 	});
 
 	const store = new Store('test');
@@ -35,16 +24,4 @@ describe('Core.Store', function () {
 			proclaim.equal(store.read(), 'TESTING');
 		});
 	});
-
-	describe('cookies', function () {
-		it('should store an array of values', function () {
-			let cookie_store = new Store('test-cookies', { storage: 'cookie' });
-
-			cookie_store.write(['one', 'two']);
-
-			cookie_store = new Store('test-cookies', { storage: 'cookie' });
-			proclaim.deepEqual(cookie_store.read(), ['one', 'two']);
-		});
-	});
-
 });

--- a/test/core/store.test.js
+++ b/test/core/store.test.js
@@ -44,24 +44,61 @@ describe('Core.Store', function () {
 		});
 
 		it('constructs a store if given a name which is a string', function() {
-			proclaim.doesNotThrow(function() {
-				new Store('test');
-			});
+			let store = new Store('test');
+			proclaim.equal(store.storageKey, 'o-tracking_test');
 		});
 
-		it('should use local storage by default', function () {
-			proclaim.equal(new Store('test').storage._type, 'localStorage');
+		it('can override the internal storageKey', function() {
+			let store = new Store('test', {nameOverride: '13.7'});
+			proclaim.equal(store.storageKey, '13.7');
 		});
 	});
+
 	describe('write()', function () {
 		it('should save a value', function () {
+			const store = new Store('test');
 			proclaim.equal(store.write('TESTING').read(), 'TESTING');
 		});
 	});
 
 	describe('read()', function () {
 		it('should retrieve a value', function () {
+			const store = new Store('test');
 			proclaim.equal(store.read(), 'TESTING');
+		});
+	});
+
+	describe('destroy()', function () {
+		it('should destroy the store', function () {
+			const store = new Store('test');
+			proclaim.equal(store.read(), 'TESTING');
+			store.destroy();
+			proclaim.equal(store.read(), null);
+		});
+	});
+
+	describe('importing from cookies', function() {
+		function cookieSave(name, value) {
+			const yearInMilliseconds = 10 * 365 * 24 * 60 * 60 * 1000;
+			const d = new Date();
+			d.setTime(d.getTime() + yearInMilliseconds);
+			const expires = 'expires=' + d.toUTCString() + ';';
+			const domain = location.hostname.match(/^(?:.+\.)?ft\.com$/) ? 'ft.com' : null;
+
+			const cookie = encodeURIComponent(name) + '=' + encodeURIComponent(value) + ';' + expires + 'path=/;' + (domain ? 'domain=.' + domain + ';' : '');
+			window.document.cookie = cookie;
+		}
+		it('should load data from the old cookie storage system if the cookie exists', function() {
+			cookieSave('origami', JSON.stringify({
+				number: 13.7
+			}));
+			const store = new Store('test', {
+				nameOverride: 'origami'
+			});
+
+			proclaim.deepStrictEqual(store.read(), {
+				number: 13.7
+			});
 		});
 	});
 });


### PR DESCRIPTION
All browsers o-tracking supports have localStorage, it does not require the cookie based fallback.
Even in incognito sessions localStorage works.

[<img width="1280" alt="browser support for localStorage" src="https://user-images.githubusercontent.com/1569131/89523263-7d1b3980-d7da-11ea-89f1-89408dd5f8e1.png">](https://caniuse.com/#feat=mdn-api_window_localstorage)
