### PR TITLE
update the comment about why the first call to `page` does not set a new root_id

### DIFF
--- a/test/events/page.test.js
+++ b/test/events/page.test.js
@@ -14,7 +14,7 @@ import event from '../../src/javascript/events/custom.js';
 describe('page', function () {
 
 	beforeEach(function () {
-		settings.destroy('page_viewed'); // Empty settings.
+		settings.destroy('page_has_already_been_viewed'); // Empty settings.
 	});
 
 	before(function () {


### PR DESCRIPTION
I found the original comment hard to understand so I decided to have an attempt at rewriting it.