### PR TITLE
 Do not send multiple page-view events if the new event is the exact same as the previously sent event

### DIFF
--- a/src/javascript/events/page-view.js
+++ b/src/javascript/events/page-view.js
@@ -20,7 +20,7 @@ const defaultPageConfig = function () {
 	};
 };
 
-let previousPageConfig = {};
+let previousPageConfigWithoutContextIDs = {};
 /**
  * Make the page tracking request.
  *
@@ -44,13 +44,17 @@ function page(config, callback) {
 		Core.setRootID();
 	}
 	settings.set('page_has_already_been_viewed', true);
-	if (isDeepEqual(previousPageConfig, config)) {
+	const configWithoutContextIDs = JSON.parse(JSON.stringify(config));
+	delete configWithoutContextIDs.context.id;
+	delete configWithoutContextIDs.context.root_id;
+
+	if (isDeepEqual(previousPageConfigWithoutContextIDs, configWithoutContextIDs)) {
 		if (settings.get('config').test) {
 			// eslint-disable-next-line no-console
 			console.warn('A page event has already been sent for this page, refusing to send a duplicate page event.');
 		}
 	} else {
-		previousPageConfig = config;
+		previousPageConfigWithoutContextIDs = configWithoutContextIDs;
 		Core.track(config, callback);
 		// Alert internally that a new page has been tracked - for single page apps for example.
 		triggerPage();

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -307,6 +307,70 @@ function containsCircularPaths(rootObject) {
 	);
 }
 
+function isDeepEqual(actual, expected) {
+	if (actual === expected) {
+		return true;
+	}
+
+	if (
+		actual &&
+		expected &&
+		typeof actual === "object" &&
+		typeof expected === "object"
+	) {
+		if (actual.constructor !== expected.constructor) {
+			return false;
+		}
+
+		if (Array.isArray(actual)) {
+			const length = actual.length;
+			if (length !== expected.length) {
+				return false;
+			}
+			for (let i = length; i-- !== 0; ) {
+				if (!isDeepEqual(actual[i], expected[i])) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		if (actual.constructor === RegExp) {
+			return (
+				actual.source === expected.source && actual.flags === expected.flags
+			);
+		}
+		if (actual.valueOf !== Object.prototype.valueOf) {
+			return actual.valueOf() === expected.valueOf();
+		}
+		if (actual.toString !== Object.prototype.toString) {
+			return actual.toString() === expected.toString();
+		}
+
+		const keys = Object.keys(actual);
+		const length = keys.length;
+		if (length !== Object.keys(expected).length) {
+			return false;
+		}
+
+		for (let i = length; i-- !== 0; ) {
+			if (!Object.prototype.hasOwnProperty.call(expected, keys[i])) {
+				return false;
+			}
+		}
+
+		for (let i = length; i-- !== 0; ) {
+			const key = keys[i];
+
+			if (!isDeepEqual(actual[key], expected[key])) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}
+
 /**
  * Utilities.
  * @alias utils
@@ -347,5 +411,6 @@ export {
 	assignIfUndefined,
 	filterProperties,
 	findCircularPathsIn,
-	containsCircularPaths
+	containsCircularPaths,
+	isDeepEqual
 };

--- a/test/events/page.test.js
+++ b/test/events/page.test.js
@@ -127,4 +127,32 @@ describe('page', function () {
 		proclaim.isFalse(callback3.called);
 
 	});
+
+	it('should not send multiple events if the page id or root_id are the only changes from the previously sent page event', function () {
+		const callback = sinon.spy();
+		const callback2 = sinon.spy();
+		const callback3 = sinon.spy();
+
+		page({
+			url: "http://www.ft.com/home/uk",
+			id: 11,
+			root_id: 22
+		}, callback);
+		proclaim.isTrue(callback.called, 'Callback not called.');
+
+		page({
+			url: "http://www.ft.com/home/uk",
+			id: 12,
+			root_id: 22
+		}, callback2);
+		proclaim.isFalse(callback2.called);
+
+		page({
+			url: "http://www.ft.com/home/uk",
+			id: 13,
+			root_id: 23
+		}, callback3);
+		proclaim.isFalse(callback3.called);
+
+	});
 });

--- a/test/events/page.test.js
+++ b/test/events/page.test.js
@@ -58,21 +58,21 @@ describe('page', function () {
 		const callback3 = sinon.spy();
 
 		page({
-			url: "http://www.ft.com/home/uk"
+			url: "http://www.ft.com/home/uk?1"
 		}, callback);
 		proclaim.ok(callback.called, 'Callback not called.');
 
 		const page1_root_id = callback.getCall(0).thisValue.context.root_id;
 
 		page({
-			url: "http://www.ft.com/home/uk"
+			url: "http://www.ft.com/home/uk?2"
 		}, callback2);
 		proclaim.ok(callback2.called, 'Callback not called.');
 
 		const page2_root_id = callback2.getCall(0).thisValue.context.root_id;
 
 		page({
-			url: "http://www.ft.com/home/uk"
+			url: "http://www.ft.com/home/uk?3"
 		}, callback3);
 		proclaim.ok(callback3.called, 'Callback not called.');
 
@@ -83,7 +83,7 @@ describe('page', function () {
 		proclaim.notEqual(page1_root_id, page3_root_id, 'root_id is not unique');
 	});
 
-	it('should have an event sent before a PV attached to the next PV sent', function () {
+	it('should have an event sent before a Page-View attached to the next Page-View sent', function () {
 		const callback = sinon.spy();
 		const callback2 = sinon.spy();
 
@@ -104,5 +104,27 @@ describe('page', function () {
 
 		const page_root_id = callback2.getCall(0).thisValue.context.root_id;
 		proclaim.equal(event_root_id, page_root_id, 'root_id should match: ' + event_root_id + '===' + page_root_id);
+	});
+
+	it('should not send multiple events if the page has not changed', function () {
+		const callback = sinon.spy();
+		const callback2 = sinon.spy();
+		const callback3 = sinon.spy();
+
+		page({
+			url: "http://www.ft.com/home/uk?1"
+		}, callback);
+		proclaim.isTrue(callback.called, 'Callback not called.');
+
+		page({
+			url: "http://www.ft.com/home/uk?1"
+		}, callback2);
+		proclaim.isFalse(callback2.called);
+
+		page({
+			url: "http://www.ft.com/home/uk?1"
+		}, callback3);
+		proclaim.isFalse(callback3.called);
+
 	});
 });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -159,7 +159,9 @@ describe('main', function () {
 		proclaim.equal(sent_data1.context.my_key, "my_val");
 
 		// Track another page
-		oTracking.page({}, callback2);
+		oTracking.page({
+			url: "http://www.ft.com/home/uk"
+		}, callback2);
 		proclaim.ok(callback2.called, 'Callback not called.');
 
 		// Ensure vars from the first track don't leak into the second
@@ -179,7 +181,9 @@ describe('main', function () {
 
 		const callback = sinon.spy();
 
-		oTracking.page({}, callback);
+		oTracking.page({
+			url: "http://www.ft.com/home/uk?1"
+		}, callback);
 
 		proclaim.ok(callback.called, 'Callback not called.');
 
@@ -200,7 +204,9 @@ describe('main', function () {
 
 		const callback = sinon.spy();
 
-		oTracking.page({}, callback);
+		oTracking.page({
+			url: "http://www.ft.com/home/uk?2"
+		}, callback);
 
 		proclaim.ok(callback.called, 'Callback not called.');
 
@@ -219,7 +225,9 @@ describe('main', function () {
 
 		const callback = sinon.spy();
 
-		oTracking.page({}, callback);
+		oTracking.page({
+			url: "http://www.ft.com/home/uk?3"
+		}, callback);
 
 		proclaim.ok(callback.called, 'Callback not called.');
 
@@ -238,7 +246,9 @@ describe('main', function () {
 
 		const callback = sinon.spy();
 
-		oTracking.page({}, callback);
+		oTracking.page({
+			url: "http://www.ft.com/home/uk?4"
+		}, callback);
 
 		proclaim.ok(callback.called, 'Callback not called.');
 
@@ -250,7 +260,9 @@ describe('main', function () {
 	it('should set system.is_live to be true if `test` is not set', function () {
 		const callback = sinon.spy();
 
-		oTracking.page({}, callback);
+		oTracking.page({
+			url: "http://www.ft.com/home/uk?5"
+		}, callback);
 
 		proclaim.ok(callback.called, 'Callback not called.');
 


### PR DESCRIPTION
Fixes https://github.com/Financial-Times/o-tracking/issues/296