### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/demos/local
+/bower_components

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import tracking from './src/javascript/tracking';
+import tracking from './src/javascript/tracking.js';
 
 /**
  * Automatically initilise o-tracking

--- a/package.json
+++ b/package.json
@@ -3,15 +3,15 @@
 	"description": "This module should be included on your product to make sending tracking requests to the Spoor API easy.",
 	"private": true,
 	"devDependencies": {
-		"eslint": "^7.1.0",
-		"eslint-config-origami-component": "^2.0.1",
-		"origami-build-tools": "^10.1.9",
-		"origami-ci-tools": "^2.0.1",
-		"remark": "^12.0.0",
-		"remark-lint": "^7.0.0",
-		"remark-preset-lint-origami-component": "^1.1.1",
-		"stylelint": "^13.5.0",
-		"stylelint-config-origami-component": "^1.0.3"
+		"eslint": "^7.8.1",
+		"eslint-config-origami-component": "^2.1.0",
+		"origami-build-tools": "^10.8.0",
+		"origami-ci-tools": "^2.0.2",
+		"remark": "^12.0.1",
+		"remark-lint": "^7.0.1",
+		"remark-preset-lint-origami-component": "^1.2.0",
+		"stylelint": "^13.7.0",
+		"stylelint-config-origami-component": "^1.0.4"
 	},
 	"repository": {
 		"type": "git",

--- a/src/javascript/core.js
+++ b/src/javascript/core.js
@@ -1,9 +1,9 @@
-import Send from './core/send';
+import Send from './core/send.js';
 
-import User from './core/user';
-import Session from './core/session';
-import settings from './core/settings';
-import utils from './utils';
+import User from './core/user.js';
+import Session from './core/session.js';
+import settings from './core/settings.js';
+import utils from './utils.js';
 
 let rootID;
 

--- a/src/javascript/core/queue.js
+++ b/src/javascript/core/queue.js
@@ -1,5 +1,5 @@
-import utils from '../utils';
-import Store from './store';
+import utils from '../utils.js';
+import Store from './store.js';
 
 /**
  * Class for handling a queue backed up by a store.

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -1,7 +1,7 @@
 import settings from './settings.js';
 import utils from '../utils.js';
 import {Queue} from './queue.js';
-import transports from './transports.js';
+import transports from './transports/index.js';
 
 /**
  * Queue queue.

--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -1,7 +1,7 @@
-import settings from './settings';
-import utils from '../utils';
-import {Queue} from './queue';
-import transports from './transports';
+import settings from './settings.js';
+import utils from '../utils.js';
+import {Queue} from './queue.js';
+import transports from './transports.js';
 
 /**
  * Queue queue.

--- a/src/javascript/core/session.js
+++ b/src/javascript/core/session.js
@@ -1,5 +1,5 @@
-import utils from '../utils';
-import Store from './store';
+import utils from '../utils.js';
+import Store from './store.js';
 
 /**
  * @typedef {object} Session

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -1,4 +1,4 @@
-import utils from '../utils';
+import utils from '../utils.js';
 
 /**
  * Class for storing data

--- a/src/javascript/core/transports/image.js
+++ b/src/javascript/core/transports/image.js
@@ -1,4 +1,4 @@
-import utils from '../../utils';
+import utils from '../../utils.js';
 
 /**
  * Image based transport mechanism

--- a/src/javascript/core/transports/index.js
+++ b/src/javascript/core/transports/index.js
@@ -1,6 +1,6 @@
-import xhr from './xhr';
-import sendBeacon from './send-beacon';
-import image from './image';
+import xhr from './xhr.js';
+import sendBeacon from './send-beacon.js';
+import image from './image.js';
 
 /**
  * Given the name of a transport, returns that transpor if it exists.

--- a/src/javascript/core/transports/index.js
+++ b/src/javascript/core/transports/index.js
@@ -5,7 +5,7 @@ import image from './image.js';
 /**
  * Given the name of a transport, returns that transpor if it exists.
  *
- * @param {string} name
+ * @param {string} name - The name of the transport to use
  * @returns {Function|undefined} - The transport function or undefined if not found.
  */
 function get(name) {

--- a/src/javascript/core/user.js
+++ b/src/javascript/core/user.js
@@ -1,5 +1,5 @@
-import utils from '../utils';
-import Store from './store';
+import utils from '../utils.js';
+import Store from './store.js';
 
 let userID;
 let store;

--- a/src/javascript/events/click.js
+++ b/src/javascript/events/click.js
@@ -1,9 +1,9 @@
 import Delegate from 'ftdomdelegate';
-import {Queue} from '../core/queue';
-import Core from '../core';
-import utils from '../utils';
-import settings from '../core/settings';
-import getTrace from '../../libs/get-trace';
+import {Queue} from '../core/queue.js';
+import Core from '../core.js';
+import utils from '../utils.js';
+import settings from '../core/settings.js';
+import getTrace from '../../libs/get-trace.js';
 
 let internalQueue;
 

--- a/src/javascript/events/component-view.js
+++ b/src/javascript/events/component-view.js
@@ -1,6 +1,6 @@
-import Core from '../core';
-import getTrace from '../../libs/get-trace';
-import utils from '../utils';
+import Core from '../core.js';
+import getTrace from '../../libs/get-trace.js';
+import utils from '../utils.js';
 
 const TRACKING_ATTRIBUTES = [
 	'componentContentId',

--- a/src/javascript/events/custom.js
+++ b/src/javascript/events/custom.js
@@ -1,5 +1,5 @@
-import Core from '../core';
-import utils from '../utils';
+import Core from '../core.js';
+import utils from '../utils.js';
 
 /**
  * Default properties for events.

--- a/src/javascript/events/page-view.js
+++ b/src/javascript/events/page-view.js
@@ -1,6 +1,6 @@
-import Core from '../core';
-import {merge, triggerPage, addEvent, isDeepEqual} from '../utils';
-import settings from '../core/settings';
+import Core from '../core.js';
+import {merge, triggerPage, addEvent, isDeepEqual} from '../utils.js';
+import settings from '../core/settings.js';
 
 settings.set('page_has_already_been_viewed', false);
 

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -1,13 +1,13 @@
-import settings from './core/settings';
-import user from './core/user';
-import session from './core/session';
-import send from './core/send';
-import event from './events/custom';
-import page from './events/page-view';
-import click from './events/click';
-import { getRootID } from './core';
-import { merge, broadcast } from './utils';
-import view from './events/component-view';
+import settings from './core/settings.js';
+import user from './core/user.js';
+import session from './core/session.js';
+import send from './core/send.js';
+import event from './events/custom.js';
+import page from './events/page-view.js';
+import click from './events/click.js';
+import { getRootID } from './core.js';
+import { merge, broadcast } from './utils.js';
+import view from './events/component-view.js';
 
 /**
  * The version of the tracking module.

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -1,12 +1,12 @@
 /**
  * Shared 'internal' scope.
  */
-import settings from './core/settings';
+import settings from './core/settings.js';
 
 /**
  * CUID Generator
  */
-import cuid from '../libs/browser-cuid';
+import cuid from '../libs/browser-cuid.js';
 
 /**
  * Record of callbacks to call when a page is tracked.

--- a/src/libs/get-trace.js
+++ b/src/libs/get-trace.js
@@ -1,6 +1,6 @@
 // Trace the element and all of its parents, collecting properties as we go
 
-import utils from '../javascript/utils';
+import utils from '../javascript/utils.js';
 
 // For a given container element, get the number of elements that match the
 // original element (siblings); and the index of the original element (position).

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,12 +1,12 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import settings from '../src/javascript/core/settings';
-import {Queue} from '../src/javascript/core/queue';
-import session from '../src/javascript/core/session';
-import send from '../src/javascript/core/send';
-import Core from '../src/javascript/core.js';
-import { errorNextSend } from './setup';
+import settings from '../src/javascript/core/settings.js';
+import {Queue} from '../src/javascript/core/queue.js';
+import session from '../src/javascript/core/session.js';
+import send from '../src/javascript/core/send.js';
+import Core from '../src/javascript/core.js.js';
+import { errorNextSend } from './setup.js';
 
 describe('Core', function () {
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -5,7 +5,7 @@ import settings from '../src/javascript/core/settings.js';
 import {Queue} from '../src/javascript/core/queue.js';
 import session from '../src/javascript/core/session.js';
 import send from '../src/javascript/core/send.js';
-import Core from '../src/javascript/core.js.js';
+import Core from '../src/javascript/core.js';
 import { errorNextSend } from './setup.js';
 
 describe('Core', function () {

--- a/test/core/queue.test.js
+++ b/test/core/queue.test.js
@@ -2,7 +2,7 @@
 /* global proclaim */
 
 
-import {Queue} from '../../src/javascript/core/queue';
+import {Queue} from '../../src/javascript/core/queue.js';
 const queue_name = 'queue_test';
 
 // PhantomJS doesn't always create a "fresh" environment...

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import Send from '../../src/javascript/core/send';
-import {Queue} from "../../src/javascript/core/queue";
+import Send from '../../src/javascript/core/send.js';
+import {Queue} from "../../src/javascript/core/queue.js";
 
 const request = {
 	id: '1.199.83760034665465.1432907605043.-56cf00f',
@@ -26,8 +26,8 @@ const request = {
 	}
 };
 
-import setup from '../setup';
-import settings from '../../src/javascript/core/settings';
+import setup from '../setup.js';
+import settings from '../../src/javascript/core/settings.js';
 
 // PhantomJS doesn't always create a "fresh" environment...
 

--- a/test/core/session.test.js
+++ b/test/core/session.test.js
@@ -1,8 +1,8 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import Store from '../../src/javascript/core/store';
-import Session from '../../src/javascript/core/session';
+import Store from '../../src/javascript/core/store.js';
+import Session from '../../src/javascript/core/session.js';
 
 describe('Core.Session', function () {
 

--- a/test/core/settings.test.js
+++ b/test/core/settings.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import Settings from '../../src/javascript/core/settings';
+import Settings from '../../src/javascript/core/settings.js';
 
 describe('Core.Settings', function () {
 

--- a/test/core/store.test.js
+++ b/test/core/store.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import Store from '../../src/javascript/core/store';
+import Store from '../../src/javascript/core/store.js';
 
 describe('Core.Store', function () {
 

--- a/test/core/user.test.js
+++ b/test/core/user.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import User from '../../src/javascript/core/user';
+import User from '../../src/javascript/core/user.js';
 
 describe('Core.User', function () {
 

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import '../setup';
+import '../setup.js';
 
-import {Queue} from '../../src/javascript/core/queue';
-import settings from '../../src/javascript/core/settings';
-import send from '../../src/javascript/core/send';
-import core from '../../src/javascript/core';
-import click from '../../src/javascript/events/click';
-import session from '../../src/javascript/core/session';
+import {Queue} from '../../src/javascript/core/queue.js';
+import settings from '../../src/javascript/core/settings.js';
+import send from '../../src/javascript/core/send.js';
+import core from '../../src/javascript/core.js';
+import click from '../../src/javascript/events/click.js';
+import session from '../../src/javascript/core/session.js';
 
 describe('click', function () {
 

--- a/test/events/component-view.test.js
+++ b/test/events/component-view.test.js
@@ -1,13 +1,13 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import '../setup';
+import '../setup.js';
 
-import settings from '../../src/javascript/core/settings';
-import send from '../../src/javascript/core/send';
-import core from '../../src/javascript/core';
-import session from '../../src/javascript/core/session';
-import componentView from '../../src/javascript/events/component-view';
+import settings from '../../src/javascript/core/settings.js';
+import send from '../../src/javascript/core/send.js';
+import core from '../../src/javascript/core.js';
+import session from '../../src/javascript/core/session.js';
+import componentView from '../../src/javascript/events/component-view.js';
 
 const config = {
 	context: {

--- a/test/events/custom.test.js
+++ b/test/events/custom.test.js
@@ -1,13 +1,13 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import '../setup';
+import '../setup.js';
 
-import {Queue} from '../../src/javascript/core/queue';
-import settings from '../../src/javascript/core/settings';
-import send from '../../src/javascript/core/send';
-import session from '../../src/javascript/core/session';
-import trackEvent from '../../src/javascript/events/custom.js';
+import {Queue} from '../../src/javascript/core/queue.js';
+import settings from '../../src/javascript/core/settings.js';
+import send from '../../src/javascript/core/send.js';
+import session from '../../src/javascript/core/session.js';
+import trackEvent from '../../src/javascript/events/custom.js.js';
 
 describe('event', function () {
 

--- a/test/events/custom.test.js
+++ b/test/events/custom.test.js
@@ -7,7 +7,7 @@ import {Queue} from '../../src/javascript/core/queue.js';
 import settings from '../../src/javascript/core/settings.js';
 import send from '../../src/javascript/core/send.js';
 import session from '../../src/javascript/core/session.js';
-import trackEvent from '../../src/javascript/events/custom.js.js';
+import trackEvent from '../../src/javascript/events/custom.js';
 
 describe('event', function () {
 

--- a/test/events/page.test.js
+++ b/test/events/page.test.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import '../setup';
+import '../setup.js';
 
-import settings from '../../src/javascript/core/settings';
-import send from '../../src/javascript/core/send';
-import session from '../../src/javascript/core/session';
-import {Queue} from '../../src/javascript/core/queue';
-import page from '../../src/javascript/events/page-view.js';
-import event from '../../src/javascript/events/custom.js';
+import settings from '../../src/javascript/core/settings.js';
+import send from '../../src/javascript/core/send.js';
+import session from '../../src/javascript/core/session.js';
+import {Queue} from '../../src/javascript/core/queue.js';
+import page from '../../src/javascript/events/page-view.js.js';
+import event from '../../src/javascript/events/custom.js.js';
 
 
 describe('page', function () {

--- a/test/events/page.test.js
+++ b/test/events/page.test.js
@@ -7,8 +7,8 @@ import settings from '../../src/javascript/core/settings.js';
 import send from '../../src/javascript/core/send.js';
 import session from '../../src/javascript/core/session.js';
 import {Queue} from '../../src/javascript/core/queue.js';
-import page from '../../src/javascript/events/page-view.js.js';
-import event from '../../src/javascript/events/custom.js.js';
+import page from '../../src/javascript/events/page-view.js';
+import event from '../../src/javascript/events/custom.js';
 
 
 describe('page', function () {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import './setup';
+import './setup.js';
 
-import settings from '../src/javascript/core/settings';
-import {Queue} from '../src/javascript/core/queue';
+import settings from '../src/javascript/core/settings.js';
+import {Queue} from '../src/javascript/core/queue.js';
 import oTracking from '../main.js';
 
 describe('main', function () {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,6 @@
 /* global sinon*/
 
-import transports from '../src/javascript/core/transports.js';
+import transports from '../src/javascript/core/transports/index.js';
 
 let willError = false;
 

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,6 @@
 /* global sinon*/
 
-import transports from '../src/javascript/core/transports';
+import transports from '../src/javascript/core/transports.js';
 
 let willError = false;
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
 
-import Utils from '../src/javascript/utils';
+import Utils from '../src/javascript/utils.js';
 
 describe('Utils', function () {
 


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing