### PR TITLE
Improve support for multiple calls to `oTracking.click.init`.

### DIFF
--- a/src/javascript/events/click.js
+++ b/src/javascript/events/click.js
@@ -6,6 +6,7 @@ import {get as getSetting} from '../core/settings.js';
 import {getTrace} from '../../libs/get-trace.js';
 
 let internalQueue;
+let delegate;
 
 // Trigger the event tracking
 const track = eventData => {
@@ -106,11 +107,11 @@ const init = (category, elementsToTrack) => {
 	};
 
 	// Activate the click event listener
-	const delegate = new Delegate(document.body);
+	delegate = delegate || new Delegate(document.body);
 	delegate.on('click', elementsToTrack, handleClickEvent(eventData), true);
 
 	// Track any queued events
-	internalQueue = new Queue('clicks');
+	internalQueue = internalQueue || new Queue('clicks');
 	runQueue();
 
 	// Listen for page requests. If this is a single page app, we can send link requests now.

--- a/src/javascript/utils.js
+++ b/src/javascript/utils.js
@@ -150,7 +150,7 @@ function broadcast(namespace, eventType, detail) {
  * @returns {void}
  */
 function onPage(cb) {
-	if (is(cb, 'function')) {
+	if (is(cb, 'function') && !page_callbacks.includes(cb)) {
 		page_callbacks.push(cb);
 	}
 }


### PR DESCRIPTION
- Reused any existing `clicks` queue.
- Reuse any existing event delegate.
- Do not run the same callback on page view multiple times.

This will allow projects to track clicks on elements which are
not tracked with the default `oTracking.click.init` call, and
allow projects to track clicks with different event categories.

For example to track non-interactive elements with the custom
data attribute `data-my-element-to-track-clicks-on`.
```
oTracking.click.init(
    'my-custom-category',
    '[data-my-element-to-track-clicks-on]'
);
```