### PR TITLE
Export an object with `init` method for `click` and `view`.

### DIFF
--- a/src/javascript/events/click.js
+++ b/src/javascript/events/click.js
@@ -118,6 +118,8 @@ const init = (category, elementsToTrack) => {
 	onPage(runQueue);
 };
 
-export {
+const click = {
 	init
 };
+
+export { click };

--- a/src/javascript/events/component-view.js
+++ b/src/javascript/events/component-view.js
@@ -80,5 +80,10 @@ const init = (opts = {}) => {
 	elementsToTrack.forEach(el => observer.observe(el));
 };
 
-export { init };
+const view = {
+	init
+};
+
+export { view };
+
 

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -4,10 +4,10 @@ import {init as initSession} from './core/session.js';
 import {init as initSend} from './core/send.js';
 import {event} from './events/custom.js';
 import {page} from './events/page-view.js';
-import {init as initClick} from './events/click.js';
+import click from './events/click.js';
 import core from './core.js';
 import { merge, broadcast } from './utils.js';
-import {init as initView} from './events/component-view.js';
+import view from './events/component-view.js';
 
 const initEvent = event.init;
 const initPage = page.init;
@@ -193,10 +193,10 @@ const tracking = {
 	destroy,
 	toString,
 	init,
-	click: initClick,
+	click,
 	event,
 	page,
-	view: initView,
+	view,
 	getRootID: core.getRootID
 };
 

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -4,10 +4,10 @@ import {init as initSession} from './core/session.js';
 import {init as initSend} from './core/send.js';
 import {event} from './events/custom.js';
 import {page} from './events/page-view.js';
-import click from './events/click.js';
+import {click} from './events/click.js';
 import core from './core.js';
 import { merge, broadcast } from './utils.js';
-import view from './events/component-view.js';
+import {view} from './events/component-view.js';
 
 const initEvent = event.init;
 const initPage = page.init;

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -7,7 +7,7 @@ import {Queue} from '../../src/javascript/core/queue.js';
 import {destroy, set} from '../../src/javascript/core/settings.js';
 import {init as initSend} from '../../src/javascript/core/send.js';
 import core from '../../src/javascript/core.js';
-import {init as initClick} from '../../src/javascript/events/click.js';
+import {click} from '../../src/javascript/events/click.js';
 import {init as initSession} from '../../src/javascript/core/session.js';
 
 describe('click', function () {
@@ -37,7 +37,7 @@ describe('click', function () {
 
 		sinon.spy(core, 'track');
 
-		initClick("blah", '#anchorA');
+		click.init("blah", '#anchorA');
 
 		const aLinkToGoogle = document.createElement('a');
 
@@ -76,7 +76,7 @@ describe('click', function () {
 
 		sinon.spy(core, 'track');
 
-		initClick("blah", '#anchorB');
+		click.init("blah", '#anchorB');
 
 		const aLinkToGoogle = document.createElement('a');
 
@@ -115,7 +115,7 @@ describe('click', function () {
 
 		sinon.spy(core, 'track');
 
-		initClick("blah", '#anchorC');
+		click.init("blah", '#anchorC');
 
 		const aLinkToSecuredrop = document.createElement('a');
 
@@ -155,9 +155,9 @@ describe('click', function () {
 	it('should not track straight away when the link points to the same domain we are currently on', function (done) {
 		sinon.spy(core, 'track');
 
-		initClick("blah", '#anchorD');
+		click.init("blah", '#anchorD');
 
-		core.track.resetHistory(); // initClick() makes a call to track() so clearing the history here to avoid false positives
+		core.track.resetHistory(); // click.init() makes a call to track() so clearing the history here to avoid false positives
 
 		const aLinkToPageOnSameDomain = document.createElement('a');
 		const currentHost = window.document.location.hostname;
@@ -196,9 +196,9 @@ describe('click', function () {
 	it('should skip the queue when data-o-tracking-skip-queue is "true" on the link', function (done) {
 		sinon.spy(core, 'track');
 
-		initClick("blah", '#anchorE');
+		click.init("blah", '#anchorE');
 
-		core.track.resetHistory(); // initClick() makes a call to track() so clearing the history here to avoid false positives
+		core.track.resetHistory(); // click.init() makes a call to track() so clearing the history here to avoid false positives
 
 		const aLinkToPageOnSameDomain = document.createElement('a');
 		const currentHost = window.document.location.hostname;

--- a/test/events/component-view.test.js
+++ b/test/events/component-view.test.js
@@ -7,7 +7,7 @@ import {set} from '../../src/javascript/core/settings.js';
 import {init as initSend} from '../../src/javascript/core/send.js';
 import core from '../../src/javascript/core.js';
 import {init as initSession} from '../../src/javascript/core/session.js';
-import {init as initComponentView} from '../../src/javascript/events/component-view.js';
+import {view} from '../../src/javascript/events/component-view.js';
 
 const config = {
 	context: {
@@ -88,7 +88,7 @@ describe('component:view', () => {
 			const text = 'component:view target for default props';
 
 			createTargetComponent(attributes, text);
-			initComponentView();
+			view.init();
 			viewed(targetComponent);
 		});
 
@@ -125,7 +125,7 @@ describe('component:view', () => {
 					},
 				};
 
-				initComponentView(opts);
+				view.init(opts);
 				viewed(targetComponent);
 			});
 
@@ -144,7 +144,7 @@ describe('component:view', () => {
 						getContextData: {},
 					};
 
-					initComponentView(opts);
+					view.init(opts);
 					viewed(targetComponent);
 				});
 
@@ -162,7 +162,7 @@ describe('component:view', () => {
 						getContextData: (el) => `${el}`,
 					};
 
-					initComponentView(opts);
+					view.init(opts);
 					viewed(targetComponent);
 				});
 
@@ -185,7 +185,7 @@ describe('component:view', () => {
 						},
 					};
 
-					initComponentView(opts);
+					view.init(opts);
 					viewed(targetComponent);
 				});
 


### PR DESCRIPTION
So `oTracking.click` becomes `oTracking.click.init` and
`oTracking.view` becomes `oTracking.view.init`.

- The documentation refers to `oTracking.click.init` and
`oTracking.view.init`. `oTracking.click` and `oTracking.view` are
undocumented.
- `oTracking.page.init` already exists, each event type will align.
`oTracking.page` is a function for sending a page event where
`oTracking.page.init` is a method for firing page events 
automatically. In the future view/click could follow the same pattern
-- e.g. to track clicks on non-interactive elements

This could be considered a breaking change but I think we should
treat this as a bugfix since there are few users of v3 and the
methods being changed are not documented.

Thanks for your help, @taraojo!