### PR TITLE
Make the version property be the correct value

### DIFF
--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -17,7 +17,7 @@ const initPage = page.init;
  *
  * @type {string}
  */
-const version = '2.0.10';
+const version = '3.0.3';
 
 /**
  * The source of this event.


### PR DESCRIPTION
This was being set to the old major version, which could cause confusion when debugging o-tracking.
We should look at some automation to ensure this value stays in sync with the version of the component