### PR TITLE
Fix bug where loading spoor-id from the cookie would silently fail

### DIFF
--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -116,14 +116,20 @@ const Store = function (name, config = {}) {
 	const oldCookieStoreData = cookieLoad(this.storageKey);
 	if (oldCookieStoreData) {
 		try {
-			const data = JSON.parse(oldCookieStoreData);
-			if (this.data) {
-				Object.assign(this.data, data);
+			if (this.storageKey === 'spoor-id') {
+				// spoor-id is stored directly as a string and not as an object
+				this.data = oldCookieStoreData;
+				cookieRemove('spoor-id');
 			} else {
-				this.data = data;
-			}
-			for (const name of Object.keys(data)) {
-				cookieRemove(name);
+				const data = JSON.parse(oldCookieStoreData);
+				if (this.data) {
+					Object.assign(this.data, data);
+				} else {
+					this.data = data;
+				}
+				for (const name of Object.keys(data)) {
+					cookieRemove(name);
+				}
 			}
 		} catch (error) {
 			broadcast('oErrors', 'log', {

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -119,7 +119,6 @@ const Store = function (name, config = {}) {
 			if (this.storageKey === 'spoor-id') {
 				// spoor-id is stored directly as a string and not as an object
 				this.data = oldCookieStoreData;
-				cookieRemove('spoor-id');
 			} else {
 				const data = JSON.parse(oldCookieStoreData);
 				if (this.data) {
@@ -128,7 +127,9 @@ const Store = function (name, config = {}) {
 					this.data = data;
 				}
 				for (const name of Object.keys(data)) {
-					cookieRemove(name);
+					if (name !== 'spoor-id') {
+						cookieRemove(name);
+					}
 				}
 			}
 		} catch (error) {

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -53,6 +53,10 @@ const Store = function (name, config = {}) {
 			return window.localStorage.setItem(name, value);
 		},
 		remove: function (name) {
+			// We attempt to remove the item from the old cookie storage
+			// because otherwise the next time o-tracking is initialised for
+			// this user, it will import the old value which was meant to
+			// have been removed.
 			cookieRemove(name);
 			return window.localStorage.removeItem(name);
 		}

--- a/src/javascript/core/store.js
+++ b/src/javascript/core/store.js
@@ -53,6 +53,7 @@ const Store = function (name, config = {}) {
 			return window.localStorage.setItem(name, value);
 		},
 		remove: function (name) {
+			cookieRemove(name);
 			return window.localStorage.removeItem(name);
 		}
 	};

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -17,7 +17,7 @@ const initPage = page.init;
  *
  * @type {string}
  */
-const version = '3.0.3';
+const version = '3.0.4';
 
 /**
  * The source of this event.

--- a/test/core/store.test.js
+++ b/test/core/store.test.js
@@ -100,5 +100,17 @@ describe('Core.Store', function () {
 				number: 13.7
 			});
 		});
+
+		context('spoor-id migration from cookie to localstorage', function() {
+			it('should load data from the old cookie storage system if the cookie exists', function() {
+				const spoorID = 'ckmypa3l700003g6e6wb33708';
+				cookieSave('spoor-id', spoorID);
+				const store = new Store('test', {
+					nameOverride: 'spoor-id',
+				});
+
+				proclaim.deepStrictEqual(store.read(), spoorID);
+			});
+		});
 	});
 });


### PR DESCRIPTION
spoor-id is stored directly as a string and not an json object, which meant json.parse would throw an error and we would not be migrating the old spoor-id value to localstorage and instead would mint a new spoor-id, which is not what we want to do.