### PR TITLE
Bug: reset the config to it's default value instead of deleting it

### DIFF
--- a/test/events/page.test.js
+++ b/test/events/page.test.js
@@ -3,7 +3,7 @@
 
 import '../setup.js';
 
-import {destroy} from '../../src/javascript/core/settings.js';
+import {destroy, set} from '../../src/javascript/core/settings.js';
 import {init as initSend} from '../../src/javascript/core/send.js';
 import {init as initSession} from '../../src/javascript/core/session.js';
 import {Queue} from '../../src/javascript/core/queue.js';
@@ -25,7 +25,7 @@ describe('page', function () {
 
 	after(function () {
 		new Queue('requests').replace([]); // Empty the queue as PhantomJS doesn't always start fresh.
-		destroy('config'); // Empty settings.
+		set('config', {}); // Empty settings.
 	});
 
 	it('should track a page', function () {


### PR DESCRIPTION
This is a bug that doesn't currently get triggered by the test runner, likely because it is the last test file to be executed, but that could change whenever karma and/or mocha is updated.

The bug is that destroy will delete the config property when what we want to do is reset the config property to it's default value, which is an empty object.

Our new test runner in obt v11 hit this bug, which is why it was spotted now