### PR TITLE
Add back the source_id property

### DIFF
--- a/src/javascript/events/click.js
+++ b/src/javascript/events/click.js
@@ -39,6 +39,9 @@ const handleClickEvent = eventData => (clickEvent, clickElement) => {
 	const { trace, customContext} = getTrace(clickElement);
 	context.domPathTokens = trace;
 	context.url = window.document.location.href || null;
+	// source_id is a field that is currently being used in some data analytics
+	// before removing this field - check with the data analytics team first to see if it is still being used
+	context.source_id = core.getRootID();
 
 	assignIfUndefined(customContext, context);
 

--- a/src/javascript/tracking.js
+++ b/src/javascript/tracking.js
@@ -17,7 +17,7 @@ const initPage = page.init;
  *
  * @type {string}
  */
-const version = '3.1.1';
+const version = '4.0.1';
 
 /**
  * The source of this event.


### PR DESCRIPTION
This property is being used in some data analytics and we have been asked to add it back

I will also backport this to v3 as we need to get this out to some products straight away