### PR TITLE
use the ingest endpoint by default and only fallback to px.gif when using the image transport mechanism

### DIFF
--- a/src/javascript/core/send.js
+++ b/src/javascript/core/send.js
@@ -96,7 +96,7 @@ function sendRequest(request, callback) {
 	/**
 	 * Default collection server.
 	 */
-	let url = 'https://spoor-api.ft.com/px.gif';
+	let url = 'https://spoor-api.ft.com/ingest';
 
 	if (request && request.category && request.action) {
 		url += `?type=${request.category}:${request.action}`;

--- a/test/core/send.test.js
+++ b/test/core/send.test.js
@@ -77,7 +77,7 @@ describe('Core.Send', function () {
 			addAndRun(request);
 			setTimeout(() => {
 				try {
-					proclaim.equal(navigator.sendBeacon.args[0][0], 'https://spoor-api.ft.com/px.gif?type=video:seek');
+					proclaim.equal(navigator.sendBeacon.args[0][0], 'https://spoor-api.ft.com/ingest?type=video:seek');
 					proclaim.ok(navigator.sendBeacon.called);
 					navigator.sendBeacon.restore();
 					destroy('config');
@@ -112,7 +112,7 @@ describe('Core.Send', function () {
 					// proclaim.equal(dummyXHR.onerror.length, 1) // it will get passed the error
 					// proclaim.equal(dummyXHR.onload.length, 0) // it will not get passed an error
 					proclaim.ok(dummyXHR.withCredentials, 'withCredentials');
-					proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/px.gif?type=video:seek", true), 'is POST');
+					proclaim.ok(dummyXHR.open.calledWith("POST", "https://spoor-api.ft.com/ingest?type=video:seek", true), 'is POST');
 					proclaim.ok(dummyXHR.setRequestHeader.calledWith('Content-type', 'application/json'), 'is application/json');
 					proclaim.ok(dummyXHR.send.calledOnce, 'calledOnce');
 					window.XMLHttpRequest = xhr;
@@ -142,7 +142,8 @@ describe('Core.Send', function () {
 			addAndRun(request);
 			setTimeout(() => {
 				try {
-					const payload = dummyImage.src.split('?')[1];
+					const [domain, payload] = dummyImage.src.split('?');
+					proclaim.equal(domain, "https://spoor-api.ft.com/px.gif");
 					proclaim.equal(decodeURIComponent(payload), 'type=video:seek&data={"system":{"transport":"image","is_live":true},"id":"1.199.83760034665465.1432907605043.-56cf00f","meta":{"page_id":"page_id","type":"event"},"user":{"spoor_session":"MS4zMTMuNTYxODY1NTk0MjM4MDQuMTQzMjkwNzYwNTAzNi4tNTZjZjAwZg==","spoor_id":"value3"},"device":{"user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.8 Safari/534.34"},"category":"video","action":"seek","context":{"key":"pos","value":"10","parent_id":"1.990.74606760405.1432907605040.-56cf00f"}}');
 					proclaim.equal(dummyImage.addEventListener.args[0][0], 'error');
 					proclaim.equal(dummyImage.addEventListener.args[0][1].length, 1);// it will get passed the error


### PR DESCRIPTION
Chris Brown (Analytics team) recommends using the /ingest endpoint for the xhr and beacon requests and only using the px.gif endpoint for the fallback image transport mechanism