### PR TITLE
Read the old clicks queue used in v2 of o-tracking and make sure all within the queue are sent to spoor

### DIFF
--- a/src/javascript/events/click.js
+++ b/src/javascript/events/click.js
@@ -3,6 +3,7 @@ import core from '../core.js';
 import {sanitise, assignIfUndefined, merge } from '../utils.js';
 import {get as getSetting} from '../core/settings.js';
 import {getTrace} from '../../libs/get-trace.js';
+import { Queue } from '../core/queue.js';
 
 let delegate;
 
@@ -72,7 +73,18 @@ const init = (category, elementsToTrack) => {
 	// Activate the click event listener
 	delegate = delegate || new Delegate(document.body);
 	delegate.on('click', elementsToTrack, handleClickEvent(eventData), true);
+
+	// Fire all click events that were stored in the old queue used by o-tracking v2
+	const clickQueue = new Queue('clicks');
+	sendAllEventsFromQueue(clickQueue);
 };
+
+function sendAllEventsFromQueue(queue) {
+	const nextLink = queue.shift();
+	if (nextLink) {
+		core.track(nextLink, () => sendAllEventsFromQueue(queue));
+	}
+}
 
 const click = {
 	init

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -59,7 +59,7 @@ describe('click', function () {
 			// Add the click event to the old 'clicks' queue which o-tracking v2 uses
 			new Queue('clicks').replace([clickEventStoredInQueue]);
 		});
-		beforeEach(function() {
+		afterEach(function() {
 			// Remove the events from the old 'clicks' queue
 			new Queue('clicks').replace([]);
 		});

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -41,8 +41,8 @@ describe('click', function () {
 		destroy('config'); // Empty settings.
 	});
 
-	it('should track an event for a click stored on the old clicks queue', function (done) {
-		const clcikEventStoredInQueue = {
+	describe('when the old clicks queue exists', function() {
+		const clickEventStoredInQueue = {
 			"created_at": 1625589236422,
 			"item": {
 				"server": "https://spoor-api.ft.com/ingest",
@@ -55,22 +55,29 @@ describe('click', function () {
 				"category": "cta"
 			}
 		};
-		// Add the click event to the old 'clicks' queue which o-tracking v2 uses
-		new Queue('clicks').replace([clcikEventStoredInQueue]);
+		beforeEach(function() {
+			// Add the click event to the old 'clicks' queue which o-tracking v2 uses
+			new Queue('clicks').replace([clickEventStoredInQueue]);
+		});
+		beforeEach(function() {
+			// Remove the events from the old 'clicks' queue
+			new Queue('clicks').replace([]);
+		});
 
-		click.init("blah", '#anchorA');
-		setTimeout(() => {
-			try {
-				proclaim.equal(core.track.calledOnce, true, "click event tracked");
-				proclaim.deepStrictEqual(core.track.firstCall.firstArg, clcikEventStoredInQueue);
+		it('should track an event for a click stored on the old clicks queue', function (done) {
+			click.init("blah", '#anchorA');
+			setTimeout(() => {
+				try {
+					proclaim.equal(core.track.calledOnce, true, "click event tracked");
+					proclaim.deepStrictEqual(core.track.firstCall.firstArg, clickEventStoredInQueue);
+					done();
+				} catch (error) {
+					done(error);
+				}
 
-				done();
-			} catch (error) {
-				done(error);
-			}
+			}, 10);
 
-		}, 10);
-
+		});
 	});
 
 	it('should track an event for a click', function (done) {
@@ -99,6 +106,7 @@ describe('click', function () {
 
 		setTimeout(() => {
 			try {
+				console.log(core.track)
 				proclaim.equal(core.track.calledOnce, true, "click event tracked");
 				proclaim.deepStrictEqual(core.track.firstCall.firstArg, {
 					"context": {

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -106,7 +106,6 @@ describe('click', function () {
 
 		setTimeout(() => {
 			try {
-				console.log(core.track)
 				proclaim.equal(core.track.calledOnce, true, "click event tracked");
 				proclaim.deepStrictEqual(core.track.firstCall.firstArg, {
 					"context": {

--- a/test/events/click.test.js
+++ b/test/events/click.test.js
@@ -41,6 +41,38 @@ describe('click', function () {
 		destroy('config'); // Empty settings.
 	});
 
+	it('should track an event for a click stored on the old clicks queue', function (done) {
+		const clcikEventStoredInQueue = {
+			"created_at": 1625589236422,
+			"item": {
+				"server": "https://spoor-api.ft.com/ingest",
+				"context": {
+					"product": "desktop",
+					"url": "https://www.example.com/",
+					"href": "https://www.example.com/",
+				},
+				"action": "click",
+				"category": "cta"
+			}
+		};
+		// Add the click event to the old 'clicks' queue which o-tracking v2 uses
+		new Queue('clicks').replace([clcikEventStoredInQueue]);
+
+		click.init("blah", '#anchorA');
+		setTimeout(() => {
+			try {
+				proclaim.equal(core.track.calledOnce, true, "click event tracked");
+				proclaim.deepStrictEqual(core.track.firstCall.firstArg, clcikEventStoredInQueue);
+
+				done();
+			} catch (error) {
+				done(error);
+			}
+
+		}, 10);
+
+	});
+
 	it('should track an event for a click', function (done) {
 
 		click.init("blah", '#anchorA');


### PR DESCRIPTION
There's currently a bug within o-tracking v3 and v4 where it does not ensure the events in the 'clicks' queue used in o-tracking v2 are sent to spoor-api.

This is an issue because it means some events can end up never being sent. The scenario that occurs in is when a product (such as front-page) uses o-tracking v2 and a user of the product clicks a link which takes them to a different product (such as article) which uses o-tracking v3 and then the user never goes back to any products which use o-tracking v2.

The fix for this is to have o-tracking read from the 'clicks' queue which v2 uses and send all the events stored in that queue off to spoor and remove them from the queue.

Note: We should backport this to v3 as well because otherwise users on v3 could end up losing this data as well