### PR TITLE
fix the name of the optional feature navigator.sendBeacon

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -19,7 +19,7 @@
 		],
 		"optional": [
 			"Promise",
-			"sendBeacon"
+			"navigator.sendBeacon"
 		]
 	},
 	"demos": [


### PR DESCRIPTION
This matches the name of the feature within polyfill.io, we have the name match polyfill.io so that the origami-build-tools can include a call to polyfill.io when running the tests on our browser support matrix